### PR TITLE
Rename library to mainspring

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,58 +7,21 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'mos6502_emulator'",
+            "name": "Debug unit tests in library 'mainspring'",
             "cargo": {
                 "args": [
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=mos6502_emulator"
+                    "--package=mainspring"
                 ],
                 "filter": {
-                    "name": "mos6502_emulator",
+                    "name": "mainspring",
                     "kind": "lib"
                 }
             },
             "args": [],
             "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug executable 'mos6502_emulator'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=mos6502_emulator",
-                    "--package=mos6502_emulator"
-                ],
-                "filter": {
-                    "name": "mos6502_emulator",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in executable 'mos6502_emulator'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=mos6502_emulator",
-                    "--package=mos6502_emulator"
-                ],
-                "filter": {
-                    "name": "mos6502_emulator",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
+        }
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mos6502_emulator"
+name = "mainspring"
 version = "0.1.0"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# mos6502_emulator
+# mainspring
 A CPU device and emulation framework focused on implementing a CPU through Instructions that emit a virtual microcode.

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -67,11 +67,11 @@ impl MOS6502 {
     /// # Examples
     ///
     /// ```
-    /// use mos6502_emulator::address_map::{
+    /// use mainspring::address_map::{
     ///     memory::{Memory, ReadOnly},
     ///     Addressable,
     /// };
-    /// use mos6502_emulator::cpu::mos6502::MOS6502;
+    /// use mainspring::cpu::mos6502::MOS6502;
     ///
     /// let (start_addr, stop_addr) = (0x6000, 0x7000);
     /// let nop_sled = [0xea; 0x7000 - 0x6000].to_vec();


### PR DESCRIPTION
# Introduction
This PR renames the framework to a more generic name, `mainspring`, as the project is no longer fully tied solely to the mos6502.
# Linked Issues
resolves #40 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
