### PR TITLE
Add CLD implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -302,6 +302,16 @@ pub struct SEC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLD;
 
+impl Offset for CLD {}
+
+impl<'a> Parser<'a, &'a [u8], CLD> for CLD {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], CLD> {
+        parcel::parsers::byte::expect_byte(0xd8)
+            .map(|_| CLD)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SED;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -204,6 +204,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
+            inst_to_operation!(mnemonic::CLD, address_mode::Implied),
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
             inst_to_operation!(mnemonic::INY, address_mode::Implied),
@@ -310,6 +311,20 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLC, address_mode::Implie
             self.offset(),
             self.cycles(),
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, false)],
+        )
+    }
+}
+
+// CLD
+
+gen_instruction_cycles_and_parser!(mnemonic::CLD, address_mode::Implied, 0xd8, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLD, address_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false)],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -31,6 +31,27 @@ fn should_generate_implied_address_mode_clc_machine_code() {
     );
 }
 
+// CLD
+
+#[test]
+fn should_generate_implied_address_mode_cld_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.carry = true;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::CLD, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false),]
+        ),
+        mc
+    );
+}
+
 // CMP
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -17,6 +17,12 @@ fn should_parse_implied_address_mode_clc_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_cld_instruction() {
+    let bytecode = [0xd8, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inx_instruction() {
     let bytecode = [0xe8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -36,6 +36,15 @@ fn should_cycle_on_clc_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_cld_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xd8]);
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(false, state.ps.decimal);
+}
+
+#[test]
 fn should_cycle_on_cmp_immediate_operation_with_inequal_operands() {
     let cpu = generate_test_cpu_with_instructions(vec![0xc9, 0xff]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This PR adds the CLD implied Instruction for the mos6502 cpu.
# Linked Issues
#88 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
