### PR TITLE
Add prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod address_map;
 
 #[macro_use]
 pub mod cpu;
+pub mod prelude;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,0 +1,5 @@
+#[allow(unused_imports)]
+use crate::address_map::{Addressable, AddressableClone};
+
+#[allow(unused_imports)]
+use crate::cpu::{register::Register, Cyclable, Offset, CPU};


### PR DESCRIPTION
# Introduction
This PR adds a prelude module with all core traits for the mainspring framework that are also cpu/architecture agnostic. These include:
- CPU,
- Register
- Cyclable
- Offset
- Addressable
- AddressableClone

# Linked Issues
resolves #115 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
