### PR TITLE
Implement SED implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -315,6 +315,16 @@ impl<'a> Parser<'a, &'a [u8], CLD> for CLD {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SED;
 
+impl Offset for SED {}
+
+impl<'a> Parser<'a, &'a [u8], SED> for SED {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], SED> {
+        parcel::parsers::byte::expect_byte(0xf8)
+            .map(|_| SED)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLI;
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -306,6 +306,27 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
     )
 }
 
+// SED
+
+#[test]
+fn should_generate_implied_address_mode_sed_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.carry = true;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::SED, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true),]
+        ),
+        mc
+    );
+}
+
 // STA
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -59,14 +59,20 @@ fn should_parse_zeropage_with_x_index_address_mode_lda_instruction() {
 }
 
 #[test]
-fn should_parse_absolute_address_mode_sta_instruction() {
-    let bytecode = [0x8d, 0x34, 0x12];
+fn should_parse_absolute_address_mode_jmp_instruction() {
+    let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);
 }
 
 #[test]
-fn should_parse_absolute_address_mode_jmp_instruction() {
-    let bytecode = [0x4c, 0x34, 0x12];
+fn should_parse_absolute_address_mode_sed_instruction() {
+    let bytecode = [0xf8, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_absolute_address_mode_sta_instruction() {
+    let bytecode = [0x8d, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -197,6 +197,15 @@ fn should_cycle_on_jmp_indirect_operation() {
 }
 
 #[test]
+fn should_cycle_on_sed_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xf8]);
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(true, state.ps.decimal);
+}
+
+#[test]
 fn should_cycle_on_tax_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xaa])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))


### PR DESCRIPTION
# Introduction
This PR implements the SED implied address mode instruction for the mos6502 processor.
# Linked Issues
#94 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
