### PR TITLE
Implement SEI implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -331,6 +331,16 @@ pub struct CLI;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SEI;
 
+impl Offset for SEI {}
+
+impl<'a> Parser<'a, &'a [u8], SEI> for SEI {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], SEI> {
+        parcel::parsers::byte::expect_byte(0x78)
+            .map(|_| SEI)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLV;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -214,6 +214,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::SED, address_mode::Implied),
+            inst_to_operation!(mnemonic::SEI, address_mode::Implied),
             inst_to_operation!(mnemonic::TAX, address_mode::Implied),
             inst_to_operation!(mnemonic::TAY, address_mode::Implied),
             inst_to_operation!(mnemonic::TSX, address_mode::Implied),
@@ -517,7 +518,7 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, address_mode::Implie
     }
 }
 
-// CLD
+// SED
 
 gen_instruction_cycles_and_parser!(mnemonic::SED, address_mode::Implied, 0xf8, 2);
 
@@ -527,6 +528,20 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::SED, address_mode::Implie
             self.offset(),
             self.cycles(),
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true)],
+        )
+    }
+}
+
+// SEI
+
+gen_instruction_cycles_and_parser!(mnemonic::SEI, address_mode::Implied, 0x78, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::SEI, address_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true)],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -311,7 +311,7 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
 #[test]
 fn should_generate_implied_address_mode_sed_machine_code() {
     let mut ps = ProcessorStatus::new();
-    ps.carry = true;
+    ps.decimal = false;
     let cpu = MOS6502::default().with_ps_register(ps);
     let op: Operation = Instruction::new(mnemonic::SED, address_mode::Implied).into();
     let mc = op.generate(&cpu);
@@ -322,6 +322,27 @@ fn should_generate_implied_address_mode_sed_machine_code() {
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true),]
+        ),
+        mc
+    );
+}
+
+// SEI
+
+#[test]
+fn should_generate_implied_address_mode_sei_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.interrupt_disable = false;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::SEI, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),]
         ),
         mc
     );

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -71,6 +71,12 @@ fn should_parse_absolute_address_mode_sed_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_address_mode_sei_instruction() {
+    let bytecode = [0x78, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sta_instruction() {
     let bytecode = [0x8d, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -102,6 +102,22 @@ fn should_cycle_on_iny_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_jmp_absolute_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x4c, 0x50, 0x60]);
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6050, state.pc.read());
+}
+
+#[test]
+fn should_cycle_on_jmp_indirect_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x6c, 0x50, 0x60]);
+    let state = cpu.run(5).unwrap();
+
+    assert_eq!(0xeaea, state.pc.read());
+}
+
+#[test]
 fn should_cycle_on_lda_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);
 
@@ -164,6 +180,24 @@ fn should_cycle_on_nop_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_sed_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xf8]);
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(true, state.ps.decimal);
+}
+
+#[test]
+fn should_cycle_on_sei_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x78]);
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(true, state.ps.interrupt_disable);
+}
+
+#[test]
 fn should_cycle_on_sta_absolute_operation() {
     let (ram_start, ram_end) = (0x0200, 0x5fff);
     let cpu = generate_test_cpu_with_instructions(vec![0x8d, 0x00, 0x02])
@@ -178,31 +212,6 @@ fn should_cycle_on_sta_absolute_operation() {
 
     assert_eq!(0xff, state.acc.read());
     assert_eq!(0xff, state.address_map.read(0x0200));
-}
-
-#[test]
-fn should_cycle_on_jmp_absolute_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0x4c, 0x50, 0x60]);
-
-    let state = cpu.run(3).unwrap();
-    assert_eq!(0x6050, state.pc.read());
-}
-
-#[test]
-fn should_cycle_on_jmp_indirect_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0x6c, 0x50, 0x60]);
-    let state = cpu.run(5).unwrap();
-
-    assert_eq!(0xeaea, state.pc.read());
-}
-
-#[test]
-fn should_cycle_on_sed_implied_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0xf8]);
-
-    let state = cpu.run(2).unwrap();
-    assert_eq!(0x6001, state.pc.read());
-    assert_eq!(true, state.ps.decimal);
 }
 
 #[test]


### PR DESCRIPTION
# Introduction
This PR implements the SEI Implied address mode instruction for the mos6502 processor.
# Linked Issues
#67 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
