### PR TITLE
Implement beq relative instruction for mo6502 processor

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -88,8 +88,22 @@ impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithY> for ZeroPageIndexedWithY {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Relative(i8);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Relative(pub i8);
+
+impl Cyclable for Relative {}
+impl Offset for Relative {}
+
+impl<'a> Parser<'a, &'a [u8], Relative> for Relative {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Relative> {
+        any_byte()
+            .map(|b| {
+                let offset = unsafe { std::mem::transmute::<u8, i8>(b) };
+                Relative(offset)
+            })
+            .parse(input)
+    }
+}
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Indirect(pub u16);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -149,6 +149,16 @@ pub struct BNE;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BEQ;
 
+impl Offset for BEQ {}
+
+impl<'a> Parser<'a, &'a [u8], BEQ> for BEQ {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], BEQ> {
+        parcel::parsers::byte::expect_byte(0xf0)
+            .map(|_| BEQ)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BPL;
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -146,6 +146,7 @@ pub struct BCS;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BNE;
 
+/// Branch on Zero. Follows branch when the Zero flag is set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BEQ;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -200,6 +200,7 @@ struct OperationParser;
 impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
+            inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
             inst_to_operation!(mnemonic::CLD, address_mode::Implied),
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
@@ -298,6 +299,17 @@ macro_rules! gen_instruction_cycles_and_parser {
             }
         }
     };
+}
+
+// BEQ
+
+gen_instruction_cycles_and_parser!(mnemonic::BEQ, address_mode::Relative, 0xf0, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BEQ, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::Relative(_) = self.address_mode;
+        MOps::new(self.offset(), self.cycles(), vec![])
+    }
 }
 
 // CLC

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -13,55 +13,57 @@ use crate::cpu::register::Register;
 // BEQ
 
 #[test]
-fn should_generate_relative_address_mode_beq_machine_code() {
+fn should_generate_beq_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
-
-    // case should jump in page
     cpu.ps.zero = true;
 
     let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(8)).into();
-    let branch_case_true_in_page_mc = op.generate(&cpu);
+    let mc = op.generate(&cpu);
 
-    // case should jump out of page
-    cpu.ps.zero = true;
-
-    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
-    let branch_case_true_out_of_page_mc = op.generate(&cpu);
-
-    // case shouldn't jump
-    cpu.ps.zero = false;
-
-    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
-    let branch_case_false_mc = op.generate(&cpu);
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
 
     assert_eq!(
         MOps::new(
             2,
             3,
-            vec![gen_write_16bit_register_microcode!(
-                WordRegisters::PC,
-                // pc - relative address - inst size
-                cpu.pc.read() + 8 - 2
-            )]
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
         ),
-        branch_case_true_in_page_mc
+        mc
     );
+}
+
+#[test]
+fn should_generate_beq_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    // case should jump out of page
+    cpu.ps.zero = true;
+
+    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
 
     assert_eq!(
         MOps::new(
             2,
             4,
-            vec![gen_write_16bit_register_microcode!(
-                WordRegisters::PC,
-                // pc - relative address - inst size
-                cpu.pc.read() - 8 - 2
-            )]
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
         ),
-        branch_case_true_out_of_page_mc
+        mc
     );
+}
 
-    // check Mops value is correct
-    assert_eq!(MOps::new(2, 2, vec![]), branch_case_false_mc);
+#[test]
+fn should_generate_beq_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.zero = false;
+
+    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
 }
 
 // CLC
@@ -74,7 +76,6 @@ fn should_generate_implied_address_mode_clc_machine_code() {
     let op: Operation = Instruction::new(mnemonic::CLC, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -95,7 +96,6 @@ fn should_generate_implied_address_mode_cld_machine_code() {
     let op: Operation = Instruction::new(mnemonic::CLD, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -120,7 +120,6 @@ fn should_generate_immediate_address_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    // check Mops value is correct
     assert_eq!(MOps::new(2, 2, expected_mops.clone()), mc);
 
     // validate mops -> vector looks correct
@@ -145,7 +144,6 @@ fn should_generate_implied_address_mode_inx_machine_code() {
     let op: Operation = Instruction::new(mnemonic::INX, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -168,7 +166,6 @@ fn should_generate_implied_address_mode_iny_machine_code() {
     let op: Operation = Instruction::new(mnemonic::INY, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -191,7 +188,6 @@ fn should_generate_implied_address_mode_nop_machine_code() {
     let op: Operation = Instruction::new(mnemonic::NOP, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(MOps::new(1, 2, vec![]), mc);
 
     // validate mops -> vector looks correct
@@ -212,7 +208,6 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
     let op: Operation = Instruction::new(mnemonic::LDA, address_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             2,
@@ -247,7 +242,6 @@ fn should_generate_zeropage_address_mode_lda_machine_code() {
     let op: Operation = Instruction::new(mnemonic::LDA, address_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             2,
@@ -289,7 +283,6 @@ fn should_generate_zeropage_indexed_with_x_address_mode_lda_machine_code() {
         Instruction::new(mnemonic::LDA, address_mode::ZeroPageIndexedWithX(0x00)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             2,
@@ -329,7 +322,6 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
     let op: Operation = Instruction::new(mnemonic::LDA, address_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             3,
@@ -370,7 +362,6 @@ fn should_generate_implied_address_mode_sed_machine_code() {
     let op: Operation = Instruction::new(mnemonic::SED, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -391,7 +382,6 @@ fn should_generate_implied_address_mode_sei_machine_code() {
     let op: Operation = Instruction::new(mnemonic::SEI, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -410,7 +400,6 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
     let op: Operation = Instruction::new(mnemonic::STA, address_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             3,
@@ -442,7 +431,6 @@ fn should_generate_absolute_address_mode_jmp_machine_code() {
     let op: Operation = Instruction::new(mnemonic::JMP, address_mode::Absolute(addr)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             3,
@@ -479,7 +467,6 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
     let op: Operation = Instruction::new(mnemonic::JMP, address_mode::Indirect(base_addr)).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             3,
@@ -518,7 +505,6 @@ fn should_generate_implied_address_mode_tax_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TAX, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -540,7 +526,6 @@ fn should_generate_implied_address_mode_tay_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TAY, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -561,7 +546,6 @@ fn should_generate_implied_address_mode_tsx_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TSX, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -582,7 +566,6 @@ fn should_generate_implied_address_mode_txa_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TXA, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -603,7 +586,6 @@ fn should_generate_implied_address_mode_txs_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TXS, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,
@@ -620,7 +602,6 @@ fn should_generate_implied_address_mode_tya_machine_code() {
     let op: Operation = Instruction::new(mnemonic::TYA, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    // check Mops value is correct
     assert_eq!(
         MOps::new(
             1,

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -10,6 +10,19 @@ use crate::cpu::mos6502::{
 };
 use crate::cpu::register::Register;
 
+// BEQ
+
+#[test]
+fn should_generate_relative_address_mode_beq_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+    let pc = cpu.pc.read();
+
+    // check Mops value is correct
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
 // CLC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -11,6 +11,12 @@ macro_rules! gen_op_parse_assertion {
 }
 
 #[test]
+fn should_parse_relative_address_mode_beq_instruction() {
+    let bytecode = [0xf0, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_clc_instruction() {
     let bytecode = [0x18, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,6 +27,26 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn beq_implied_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
+    cpu.ps.zero = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+    assert_eq!(false, state.ps.carry);
+}
+
+#[test]
+fn beq_implied_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
+    cpu.ps.zero = false;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(false, state.ps.carry);
+}
+
+#[test]
 fn should_cycle_on_clc_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x18]);
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -31,9 +31,19 @@ fn beq_implied_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
     cpu.ps.zero = true;
 
-    let state = cpu.run(2).unwrap();
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
     assert_eq!(0x6008, state.pc.read());
-    assert_eq!(false, state.ps.carry);
+}
+
+#[test]
+fn beq_implied_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0xf8]);
+    cpu.ps.zero = true;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
 }
 
 #[test]
@@ -43,7 +53,6 @@ fn beq_implied_operation_should_not_jump_when_zero_unset() {
 
     let state = cpu.run(2).unwrap();
     assert_eq!(0x6002, state.pc.read());
-    assert_eq!(false, state.ps.carry);
 }
 
 #[test]


### PR DESCRIPTION
# Introduction
Implements the BEQ relative instruction for the mos6502 processor. This includes the addition of a `Page` type to handle calculating page boundaries for the purpose of incurring page boundary penalties when jumping across those bounds.

# Linked Issues
#93 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
