### PR TITLE
Implement BNE relative address mode instruction for the mos6502

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -143,8 +143,19 @@ pub struct BCC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCS;
 
+/// Branch on Zero. Follows branch when the Zero flag is not set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BNE;
+
+impl Offset for BNE {}
+
+impl<'a> Parser<'a, &'a [u8], BNE> for BNE {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], BNE> {
+        parcel::parsers::byte::expect_byte(0xd0)
+            .map(|_| BNE)
+            .parse(input)
+    }
+}
 
 /// Branch on Zero. Follows branch when the Zero flag is set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -36,7 +36,6 @@ fn should_generate_beq_machine_code_with_branch_penalty() {
 #[test]
 fn should_generate_beq_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
-    // case should jump out of page
     cpu.ps.zero = true;
 
     let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
@@ -61,6 +60,61 @@ fn should_generate_beq_machine_code_with_no_jump() {
     cpu.ps.zero = false;
 
     let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
+// BNE
+
+#[test]
+fn should_generate_bne_machine_code_with_branch_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.zero = false;
+
+    let op: Operation = Instruction::new(mnemonic::BNE, address_mode::Relative(8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bne_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.zero = false;
+
+    let op: Operation = Instruction::new(mnemonic::BNE, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bne_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.zero = true;
+
+    let op: Operation = Instruction::new(mnemonic::BNE, address_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(MOps::new(2, 2, vec![]), mc);

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -17,6 +17,12 @@ fn should_parse_relative_address_mode_beq_instruction() {
 }
 
 #[test]
+fn should_parse_relative_address_mode_bne_instruction() {
+    let bytecode = [0xd0, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_clc_instruction() {
     let bytecode = [0x18, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -56,6 +56,35 @@ fn beq_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn bne_implied_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0x08]);
+    cpu.ps.zero = false;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bne_implied_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0xf8]);
+    cpu.ps.zero = false;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bne_implied_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0x08]);
+    cpu.ps.zero = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
 fn should_cycle_on_clc_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x18]);
 


### PR DESCRIPTION
# Introduction
This PR includes the BNE branching instruction for the mos6502 along with a function for handling branching that simplifies the repetitive implementation of the conditions.

# Linked Issues
#87 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
