### PR TITLE
Implement INC absolute instruction

### DIFF
--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -40,7 +40,7 @@ impl<T> Memory<T> {
     /// address.
     pub fn new(start_address: u16, stop_address: u16) -> Self {
         let mut data = Vec::new();
-        data.resize((stop_address - start_address) as usize, 0);
+        data.resize((stop_address - start_address) as usize + 1, 0);
         Memory {
             mem_type: PhantomData,
             start_address,

--- a/src/address_map/mod.rs
+++ b/src/address_map/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::{cmp::Eq, fmt::Debug, hash::Hash, ops::Range};
+use std::{cmp::Eq, fmt::Debug, hash::Hash, ops::RangeInclusive};
 
 pub mod memory;
 
@@ -52,7 +52,7 @@ pub struct AddressMap<O: Into<usize>>
 where
     O: Into<usize> + Debug + Clone + Copy,
 {
-    inner: HashMap<Range<O>, Box<dyn Addressable<O>>>,
+    inner: HashMap<RangeInclusive<O>, Box<dyn Addressable<O>>>,
 }
 
 impl<O> fmt::Debug for AddressMap<O>
@@ -60,7 +60,7 @@ where
     O: Into<usize> + Debug + Clone + Copy,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let keys: Vec<&Range<O>> = self.inner.keys().collect();
+        let keys: Vec<&RangeInclusive<O>> = self.inner.keys().collect();
         write!(f, "AddressMap {:?}", keys)
     }
 }
@@ -79,13 +79,13 @@ where
     /// an addressable type for receiving read/write requests.
     pub fn register(
         mut self,
-        range: Range<O>,
+        range: RangeInclusive<O>,
         addr_space: Box<dyn Addressable<O>>,
     ) -> Result<AddressMap<O>, RegistrationError> {
         self.inner
             .keys()
             .map(|key| {
-                if key.contains(&range.start) || key.contains(&range.end) {
+                if key.contains(range.start()) || key.contains(range.end()) {
                     Err(format!(
                         "address space {:?} overlaps with {:?}",
                         &range, &key

--- a/src/address_map/tests/memory.rs
+++ b/src/address_map/tests/memory.rs
@@ -30,7 +30,7 @@ fn should_throw_error_when_write_is_attempted_on_readonly_memory() {
 #[test]
 fn should_dump_entire_state_of_memory() {
     let mut expected: Vec<u8> = Vec::new();
-    expected.resize(std::u16::MAX as usize, 0);
+    expected.resize(std::u16::MAX as usize + 1, 0);
     expected[0x8000 as usize] = 0xff;
 
     let mut mem: Memory<ReadWrite> = Memory::new(0, std::u16::MAX);
@@ -62,5 +62,5 @@ fn should_correctly_calculate_offsets() {
     let first_value = data[0];
 
     assert_eq!(0xff, first_value);
-    assert_eq!(0x8000 - 1, data.len());
+    assert_eq!(0x8000, data.len());
 }

--- a/src/address_map/tests/mod.rs
+++ b/src/address_map/tests/mod.rs
@@ -8,14 +8,14 @@ mod memory;
 macro_rules! u16_address_map {
     () => {
         $crate::address_map::AddressMap::<u16>::new().register(
-            0..std::u16::MAX,
+            0..=std::u16::MAX,
             Box::new($crate::address_map::memory::Memory::<
                 $crate::address_map::memory::ReadWrite,
             >::new(0, std::u16::MAX)),
         )
     };
     ($am:expr) => {
-        $crate::address_map::AddressMap::<u16>::new().register(0..std::u16::MAX, Box::new($am))
+        $crate::address_map::AddressMap::<u16>::new().register(0..=std::u16::MAX, Box::new($am))
     };
     ($range:expr, $am:expr) => {
         $crate::address_map::AddressMap::<u16>::new().register($range, Box::new($am))
@@ -24,15 +24,15 @@ macro_rules! u16_address_map {
 
 #[test]
 fn should_register_valid_memory() {
-    let am = u16_address_map!(0..std::u16::MAX, Memory::<ReadOnly>::new(0, std::u16::MAX));
+    let am = u16_address_map!(0..=std::u16::MAX, Memory::<ReadOnly>::new(0, std::u16::MAX));
     assert!(am.is_ok());
 }
 
 #[test]
 fn should_fail_when_registering_overlapping_address_space() {
-    let am = u16_address_map!(0..0x8000, Memory::<ReadOnly>::new(0, 0x8000)).unwrap();
+    let am = u16_address_map!(0..=0x7fff, Memory::<ReadOnly>::new(0, 0x7fff)).unwrap();
     assert!(am
-        .register(0..0x8000, Box::new(Memory::<ReadOnly>::new(0, 0x8000)))
+        .register(0..=0x7fff, Box::new(Memory::<ReadOnly>::new(0, 0x7fff)))
         .is_err());
 }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,6 +1,6 @@
 extern crate parcel;
 use std::convert::TryFrom;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 use crate::{
     address_map::{
@@ -79,14 +79,14 @@ impl MOS6502 {
     /// assert!(
     ///     MOS6502::default()
     ///         .register_address_space(
-    ///             start_addr..stop_addr,
+    ///             start_addr..=stop_addr,
     ///             Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
     ///         ).is_ok()
     ///     )
     /// ```
     pub fn register_address_space(
         mut self,
-        space: Range<u16>,
+        space: RangeInclusive<u16>,
         addr_space: impl Addressable<u16> + 'static,
     ) -> Result<Self, String> {
         let am = self.address_map;
@@ -143,12 +143,12 @@ impl Default for MOS6502 {
         Self {
             address_map: AddressMap::new()
                 .register(
-                    0x0000..0x00FF,
+                    0x0000..=0x00FF,
                     Box::new(Memory::<ReadWrite>::new(0x0000, 0x00FF)),
                 )
                 .unwrap()
                 .register(
-                    0x0100..0x01FF,
+                    0x0100..=0x01FF,
                     Box::new(Memory::<ReadWrite>::new(0x0100, 0x01FF)),
                 )
                 .unwrap(),

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -56,6 +56,16 @@ pub struct SBC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INC;
 
+impl Offset for INC {}
+
+impl<'a> Parser<'a, &'a [u8], INC> for INC {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], INC> {
+        parcel::parsers::byte::expect_byte(0xee)
+            .map(|_| INC)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INX;
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -190,6 +190,29 @@ fn should_generate_immediate_address_mode_cmp_machine_code() {
     )
 }
 
+// INC
+
+#[test]
+fn should_generate_implied_address_mode_inc_machine_code() {
+    let mut cpu = MOS6502::default();
+    cpu.address_map.write(0x01ff, 0x05).unwrap();
+    let op: Operation = Instruction::new(mnemonic::INC, address_mode::Absolute(0x01ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x01ff, 0x06),
+            ]
+        ),
+        mc
+    );
+}
+
 // INX
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -35,6 +35,12 @@ fn should_parse_implied_address_mode_cld_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_inc_instruction() {
+    let bytecode = [0xee, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inx_instruction() {
     let bytecode = [0xe8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -20,7 +20,7 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
         .unwrap()
         .with_pc_register(register::ProgramCounter::with_value(start_addr))
         .register_address_space(
-            start_addr..stop_addr,
+            start_addr..=stop_addr,
             Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
         )
         .unwrap()
@@ -136,6 +136,16 @@ fn should_cycle_on_cmp_immediate_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_inc_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xee, 0xff, 0x01]);
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(1, state.address_map.read(0x01ff));
+    assert_eq!((false, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
 fn should_cycle_on_inx_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xe8])
         .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(127));
@@ -213,7 +223,7 @@ fn should_cycle_on_lda_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xad, 0x00, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
         .register_address_space(
-            ram_start..ram_end,
+            ram_start..=ram_end,
             Memory::<ReadWrite>::new(ram_start, ram_end),
         )
         .unwrap();
@@ -261,7 +271,7 @@ fn should_cycle_on_sta_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x8d, 0x00, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
         .register_address_space(
-            ram_start..ram_end,
+            ram_start..=ram_end,
             Memory::<ReadWrite>::new(ram_start, ram_end),
         )
         .unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the INC absolute address mode for the mos6502 processor. In addition to implementing this instruction, it updates the addressable types to use an inclusive range rather than an exclusive range to define their address space, this makes it more explicitly clear what the exact start and end address of the memory space is.

# Linked Issues
#91
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
