### PR TITLE
implement BCC instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -150,6 +150,16 @@ pub struct BIT;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCC;
 
+impl Offset for BCC {}
+
+impl<'a> Parser<'a, &'a [u8], BCC> for BCC {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], BCC> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0x90)])
+            .map(|_| BCC)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCS;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -231,6 +231,7 @@ struct OperationParser;
 impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
+            inst_to_operation!(mnemonic::BCC, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
@@ -364,6 +365,18 @@ fn branch_on_case(
     MOps::new(inst_offset, cycles + branch_penalty, mc)
 }
 
+// BCC
+
+gen_instruction_cycles_and_parser!(mnemonic::BCC, address_mode::Relative, 0x90, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BCC, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::Relative(offset) = self.address_mode;
+
+        branch_on_case(!cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
+    }
+}
+
 // BEQ
 
 gen_instruction_cycles_and_parser!(mnemonic::BEQ, address_mode::Relative, 0xf0, 2);
@@ -375,6 +388,8 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::BEQ, address_mode::Relati
         branch_on_case(cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
     }
 }
+
+// BNE
 
 gen_instruction_cycles_and_parser!(mnemonic::BNE, address_mode::Relative, 0xd0, 2);
 

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -11,6 +11,12 @@ macro_rules! gen_op_parse_assertion {
 }
 
 #[test]
+fn should_parse_relative_address_mode_bcc_instruction() {
+    let bytecode = [0x90, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_relative_address_mode_beq_instruction() {
     let bytecode = [0xf0, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,6 +27,35 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn bcc_implied_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
+    cpu.ps.carry = false;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bcc_implied_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0xf8]);
+    cpu.ps.carry = false;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bcc_implied_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
+    cpu.ps.carry = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
 fn beq_implied_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
     cpu.ps.zero = true;


### PR DESCRIPTION
# Introduction
This PR implements the BCC relative instruction for the mos6502 cpu.
# Linked Issues
#72 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
