### PR TITLE
Implement BCS relative instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -163,6 +163,16 @@ impl<'a> Parser<'a, &'a [u8], BCC> for BCC {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCS;
 
+impl Offset for BCS {}
+
+impl<'a> Parser<'a, &'a [u8], BCS> for BCS {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], BCS> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0xb0)])
+            .map(|_| BCS)
+            .parse(input)
+    }
+}
+
 /// Branch on Zero. Follows branch when the Zero flag is not set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BNE;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -232,6 +232,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::BCC, address_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BCS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
@@ -374,6 +375,18 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::BCC, address_mode::Relati
         let address_mode::Relative(offset) = self.address_mode;
 
         branch_on_case(!cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
+    }
+}
+
+// BCS
+
+gen_instruction_cycles_and_parser!(mnemonic::BCS, address_mode::Relative, 0xb0, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BCS, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::Relative(offset) = self.address_mode;
+
+        branch_on_case(cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -59,7 +59,62 @@ fn should_generate_bcc_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = true;
 
-    let op: Operation = Instruction::new(mnemonic::BEQ, address_mode::Relative(-8)).into();
+    let op: Operation = Instruction::new(mnemonic::BCC, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
+// BCS
+
+#[test]
+fn should_generate_bcs_machine_code_with_branch_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.carry = true;
+
+    let op: Operation = Instruction::new(mnemonic::BCS, address_mode::Relative(8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bcs_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.carry = true;
+
+    let op: Operation = Instruction::new(mnemonic::BCS, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bcs_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.carry = false;
+
+    let op: Operation = Instruction::new(mnemonic::BCS, address_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(MOps::new(2, 2, vec![]), mc);

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -17,6 +17,12 @@ fn should_parse_relative_address_mode_bcc_instruction() {
 }
 
 #[test]
+fn should_parse_relative_address_mode_bcs_instruction() {
+    let bytecode = [0xb0, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_relative_address_mode_beq_instruction() {
     let bytecode = [0xf0, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -56,6 +56,35 @@ fn bcc_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn bcs_implied_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0x08]);
+    cpu.ps.carry = true;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bcs_implied_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0xf8]);
+    cpu.ps.carry = true;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bcs_implied_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0x08]);
+    cpu.ps.carry = false;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
 fn beq_implied_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
     cpu.ps.zero = true;


### PR DESCRIPTION
# Introduction
This PR implements the BCS relative address mode instruction for the mos6502 processor
# Linked Issues
#79 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
