### PR TITLE
Add CLI implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -380,6 +380,16 @@ impl<'a> Parser<'a, &'a [u8], SED> for SED {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLI;
 
+impl Offset for CLI {}
+
+impl<'a> Parser<'a, &'a [u8], CLI> for CLI {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], CLI> {
+        parcel::parsers::byte::expect_byte(0x58)
+            .map(|_| CLI)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SEI;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -237,6 +237,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
             inst_to_operation!(mnemonic::CLD, address_mode::Implied),
+            inst_to_operation!(mnemonic::CLI, address_mode::Implied),
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
@@ -438,6 +439,23 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLD, address_mode::Implie
             self.offset(),
             self.cycles(),
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false)],
+        )
+    }
+}
+
+// CLI
+
+gen_instruction_cycles_and_parser!(mnemonic::CLI, address_mode::Implied, 0x58, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLI, address_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_flag_set_microcode!(
+                ProgramStatusFlags::Interrupt,
+                false
+            )],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -270,6 +270,29 @@ fn should_generate_implied_address_mode_cld_machine_code() {
     );
 }
 
+// CLI
+
+#[test]
+fn should_generate_implied_address_mode_cli_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.interrupt_disable = true;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::CLI, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(
+                ProgramStatusFlags::Interrupt,
+                false
+            )]
+        ),
+        mc
+    );
+}
+
 // CMP
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -47,6 +47,12 @@ fn should_parse_implied_address_mode_cld_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_cli_instruction() {
+    let bytecode = [0x58, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inc_instruction() {
     let bytecode = [0xee, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -161,6 +161,16 @@ fn should_cycle_on_cld_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_cli_implied_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x58]);
+    cpu.ps.interrupt_disable = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(false, state.ps.interrupt_disable);
+}
+
+#[test]
 fn should_cycle_on_cmp_immediate_operation_with_inequal_operands() {
     let cpu = generate_test_cpu_with_instructions(vec![0xc9, 0xff]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This PR adds the CLI implied instruction for the mos6502 cpu.
# Linked Issues
#62 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
