### PR TITLE
Implement CLV implied instruction.

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -406,6 +406,16 @@ impl<'a> Parser<'a, &'a [u8], SEI> for SEI {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLV;
 
+impl Offset for CLV {}
+
+impl<'a> Parser<'a, &'a [u8], CLV> for CLV {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], CLV> {
+        parcel::parsers::byte::expect_byte(0xb8)
+            .map(|_| CLV)
+            .parse(input)
+    }
+}
+
 // Misc
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BRK;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -238,6 +238,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
             inst_to_operation!(mnemonic::CLD, address_mode::Implied),
             inst_to_operation!(mnemonic::CLI, address_mode::Implied),
+            inst_to_operation!(mnemonic::CLV, address_mode::Implied),
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
@@ -456,6 +457,20 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLI, address_mode::Implie
                 ProgramStatusFlags::Interrupt,
                 false
             )],
+        )
+    }
+}
+
+// CLV
+
+gen_instruction_cycles_and_parser!(mnemonic::CLV, address_mode::Implied, 0xb8, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CLV, address_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false)],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -293,6 +293,26 @@ fn should_generate_implied_address_mode_cli_machine_code() {
     );
 }
 
+// CLV
+
+#[test]
+fn should_generate_implied_address_mode_clv_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.overflow = true;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::CLV, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false)]
+        ),
+        mc
+    );
+}
+
 // CMP
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -53,6 +53,12 @@ fn should_parse_implied_address_mode_cli_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_clv_instruction() {
+    let bytecode = [0xb8, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inc_instruction() {
     let bytecode = [0xee, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -171,6 +171,16 @@ fn should_cycle_on_cli_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_clv_implied_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb8]);
+    cpu.ps.overflow = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(false, state.ps.overflow);
+}
+
+#[test]
 fn should_cycle_on_cmp_immediate_operation_with_inequal_operands() {
     let cpu = generate_test_cpu_with_instructions(vec![0xc9, 0xff]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This PR implements the CLV implied instruction for the mos6502 processor.
# Linked Issues
#80 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
