### PR TITLE
Implement SEC implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -351,6 +351,16 @@ impl<'a> Parser<'a, &'a [u8], CLC> for CLC {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SEC;
 
+impl Offset for SEC {}
+
+impl<'a> Parser<'a, &'a [u8], SEC> for SEC {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], SEC> {
+        parcel::parsers::byte::expect_byte(0x38)
+            .map(|_| SEC)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLD;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -251,6 +251,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
+            inst_to_operation!(mnemonic::SEC, address_mode::Implied),
             inst_to_operation!(mnemonic::SED, address_mode::Implied),
             inst_to_operation!(mnemonic::SEI, address_mode::Implied),
             inst_to_operation!(mnemonic::TAX, address_mode::Implied),
@@ -683,6 +684,20 @@ gen_instruction_cycles_and_parser!(mnemonic::NOP, address_mode::Implied, 0xea, 2
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, address_mode::Implied> {
     fn generate(self, _: &MOS6502) -> MOps {
         MOps::new(self.offset(), self.cycles(), vec![])
+    }
+}
+
+// SEC
+
+gen_instruction_cycles_and_parser!(mnemonic::SEC, address_mode::Implied, 0x38, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::SEC, address_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, true)],
+        )
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -582,6 +582,26 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
     )
 }
 
+// SEC
+
+#[test]
+fn should_generate_implied_address_mode_sec_machine_code() {
+    let mut ps = ProcessorStatus::new();
+    ps.carry = false;
+    let cpu = MOS6502::default().with_ps_register(ps);
+    let op: Operation = Instruction::new(mnemonic::SEC, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),]
+        ),
+        mc
+    );
+}
+
 // SED
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -107,6 +107,12 @@ fn should_parse_absolute_address_mode_jmp_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_address_mode_sec_instruction() {
+    let bytecode = [0x38, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sed_instruction() {
     let bytecode = [0xf8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -326,6 +326,16 @@ fn should_cycle_on_nop_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_sec_implied_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x38]);
+    cpu.ps.carry = false;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(true, state.ps.carry);
+}
+
+#[test]
 fn should_cycle_on_sed_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xf8]);
 


### PR DESCRIPTION
# Introduction
This PR implements the SEC implied instruction for the mos6502 processor.
# Linked Issues
#57 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
