### PR TITLE
Add LDA absolute indexed with x instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -122,8 +122,22 @@ impl<'a> Parser<'a, &'a [u8], Indirect> for Indirect {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct AbsoluteIndexedWithX(u16);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct AbsoluteIndexedWithX(pub u16);
+
+impl Offset for AbsoluteIndexedWithX {
+    fn offset(&self) -> usize {
+        2
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithX> for AbsoluteIndexedWithX {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], AbsoluteIndexedWithX> {
+        parcel::take_n(any_byte(), 2)
+            .map(|b| AbsoluteIndexedWithX(u16::from_le_bytes([b[0], b[1]])))
+            .parse(input)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithY(u16);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -15,6 +15,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
             parcel::parsers::byte::expect_byte(0xa5),
             parcel::parsers::byte::expect_byte(0xb5),
             parcel::parsers::byte::expect_byte(0xad),
+            parcel::parsers::byte::expect_byte(0xbd),
         ])
         .map(|_| LDA)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -101,6 +101,12 @@ fn should_parse_zeropage_with_x_index_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_x_address_mode_lda_instruction() {
+    let bytecode = [0xbd, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_jmp_instruction() {
     let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -315,6 +315,18 @@ fn should_cycle_on_lda_absolute_operation() {
 }
 
 #[test]
+fn should_cycle_on_lda_absolute_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xbd, 0x00, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
     let state = cpu.run(3).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the LDA Absolute,X instruction for the mos6502 processor.

# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
