### PR TITLE
Add LDA absolute indexed with y instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -139,8 +139,22 @@ impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithX> for AbsoluteIndexedWithX {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct AbsoluteIndexedWithY(u16);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct AbsoluteIndexedWithY(pub u16);
+
+impl Offset for AbsoluteIndexedWithY {
+    fn offset(&self) -> usize {
+        2
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithY> for AbsoluteIndexedWithY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], AbsoluteIndexedWithY> {
+        parcel::take_n(any_byte(), 2)
+            .map(|b| AbsoluteIndexedWithY(u16::from_le_bytes([b[0], b[1]])))
+            .parse(input)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndexedIndirect(u8);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -16,6 +16,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
             parcel::parsers::byte::expect_byte(0xb5),
             parcel::parsers::byte::expect_byte(0xad),
             parcel::parsers::byte::expect_byte(0xbd),
+            parcel::parsers::byte::expect_byte(0xb9),
         ])
         .map(|_| LDA)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -250,6 +250,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::LDA, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithX::default()),
+            inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithY::default()),
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::SEC, address_mode::Implied),
@@ -684,12 +685,41 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
     fn generate(self, cpu: &MOS6502) -> MOps {
         let address_mode::AbsoluteIndexedWithX(addr) = self.address_mode;
         let x = cpu.x.read();
-        let x_indexed_addr = addr + x as u16;
-        let indirect_value = cpu.address_map.read(x_indexed_addr);
-        let value = Operand::new(indirect_value);
+        let indexed_addr = addr + x as u16;
+        let indexed_value = cpu.address_map.read(indexed_addr);
+        let value = Operand::new(indexed_value);
 
         // if the branch crosses a page boundary pay a 1 cycle penalty.
-        let branch_penalty = if !Page::from(addr).contains(x_indexed_addr) {
+        let branch_penalty = if !Page::from(addr).contains(indexed_addr) {
+            1
+        } else {
+            0
+        };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::AbsoluteIndexedWithY, 0xb9, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::AbsoluteIndexedWithY> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::AbsoluteIndexedWithY(addr) = self.address_mode;
+        let y = cpu.y.read();
+        let indexed_addr = addr + y as u16;
+        let indexed_value = cpu.address_map.read(indexed_addr);
+        let value = Operand::new(indexed_value);
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(addr).contains(indexed_addr) {
             1
         } else {
             0

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -565,7 +565,78 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
         mc
     );
 
-    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_x_address_mode_lda_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::LDA, address_mode::AbsoluteIndexedWithX(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00)
+            ]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_y_address_mode_lda_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::LDA, address_mode::AbsoluteIndexedWithY(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00)
+            ]
+        ),
+        mc
+    );
+
     assert_eq!(
         vec![
             vec![],

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -107,6 +107,12 @@ fn should_parse_absolute_indexed_with_x_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_y_address_mode_lda_instruction() {
+    let bytecode = [0xb9, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_jmp_instruction() {
     let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -327,6 +327,18 @@ fn should_cycle_on_lda_absolute_indexed_with_x_operation() {
 }
 
 #[test]
+fn should_cycle_on_lda_absolute_indexed_with_y_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb9, 0x00, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
     let state = cpu.run(3).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the LDA Absolute Indexed with Y instruction for the mos6502 processor.
# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
