### PR TITLE
Implement LDA X-Indexed,Indirect instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -156,8 +156,16 @@ impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithY> for AbsoluteIndexedWithY {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct IndexedIndirect(u8);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct XIndexedIndirect(pub u8);
+
+impl Offset for XIndexedIndirect {}
+
+impl<'a> Parser<'a, &'a [u8], XIndexedIndirect> for XIndexedIndirect {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], XIndexedIndirect> {
+        any_byte().map(|b| XIndexedIndirect(b)).parse(input)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndirectIndexed(u8);

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -163,7 +163,7 @@ impl Offset for XIndexedIndirect {}
 
 impl<'a> Parser<'a, &'a [u8], XIndexedIndirect> for XIndexedIndirect {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], XIndexedIndirect> {
-        any_byte().map(|b| XIndexedIndirect(b)).parse(input)
+        any_byte().map(XIndexedIndirect).parse(input)
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -17,6 +17,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
             parcel::parsers::byte::expect_byte(0xad),
             parcel::parsers::byte::expect_byte(0xbd),
             parcel::parsers::byte::expect_byte(0xb9),
+            parcel::parsers::byte::expect_byte(0xa1),
         ])
         .map(|_| LDA)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -251,6 +251,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithY::default()),
+            inst_to_operation!(mnemonic::LDA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::SEC, address_mode::Implied),
@@ -728,6 +729,31 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
         MOps::new(
             self.offset(),
             self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::XIndexedIndirect, 0xa1, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::XIndexedIndirect> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::XIndexedIndirect(addr) = self.address_mode;
+        let x = cpu.x.read();
+        let zpage_base_addr = addr as u16 + x as u16;
+        let indirect_addr = u16::from_le_bytes([
+            cpu.address_map.read(zpage_base_addr),
+            cpu.address_map.read(zpage_base_addr + 1),
+        ]);
+        let value = Operand::new(cpu.address_map.read(indirect_addr));
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -653,6 +653,49 @@ fn should_generate_absolute_indexed_with_y_address_mode_lda_machine_code() {
     )
 }
 
+#[test]
+fn should_generate_x_indexed_indirect_address_mode_lda_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::LDA, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea)
+            ]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // SEC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -113,6 +113,12 @@ fn should_parse_absolute_indexed_with_y_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_x_indexed_indirect_address_mode_lda_instruction() {
+    let bytecode = [0xa1, 0x12, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_jmp_instruction() {
     let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -339,6 +339,20 @@ fn should_cycle_on_lda_absolute_indexed_with_y_operation() {
 }
 
 #[test]
+fn should_cycle_on_lda_x_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xa1, 0x05])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x00));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xea, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
     let state = cpu.run(3).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the LDA X-Indexed,Indirect instruction for the mos6502 processor.

# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
