### PR TITLE
Implement LDA Indirect,Y-Indexed instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -167,5 +167,13 @@ impl<'a> Parser<'a, &'a [u8], XIndexedIndirect> for XIndexedIndirect {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct IndirectIndexed(u8);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct IndirectYIndexed(pub u8);
+
+impl Offset for IndirectYIndexed {}
+
+impl<'a> Parser<'a, &'a [u8], IndirectYIndexed> for IndirectYIndexed {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], IndirectYIndexed> {
+        any_byte().map(IndirectYIndexed).parse(input)
+    }
+}

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -18,6 +18,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
             parcel::parsers::byte::expect_byte(0xbd),
             parcel::parsers::byte::expect_byte(0xb9),
             parcel::parsers::byte::expect_byte(0xa1),
+            parcel::parsers::byte::expect_byte(0xb1),
         ])
         .map(|_| LDA)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -696,6 +696,48 @@ fn should_generate_x_indexed_indirect_address_mode_lda_machine_code() {
     )
 }
 
+#[test]
+fn should_generate_indirect_y_indexed_address_mode_lda_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::LDA, address_mode::IndirectYIndexed(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea)
+            ]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // SEC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -119,6 +119,12 @@ fn should_parse_x_indexed_indirect_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_indirect_y_indexed_address_mode_lda_instruction() {
+    let bytecode = [0xb1, 0x12, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_jmp_instruction() {
     let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -341,9 +341,23 @@ fn should_cycle_on_lda_absolute_indexed_with_y_operation() {
 #[test]
 fn should_cycle_on_lda_x_indexed_indirect_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xa1, 0x05])
-        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x00));
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00));
     cpu.address_map.write(0x05, 0xff).unwrap();
     cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xea, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
+fn should_cycle_on_lda_indirect_y_indexed_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb1, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap();
 
     let state = cpu.run(6).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the LDA Indirect,Y-Indexed instruction for the mos6502 processor.
# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
