### PR TITLE
Implement STA zeropage indexed with X

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -64,6 +64,20 @@ impl<'a> Parser<'a, &'a [u8], ZeroPage> for ZeroPage {
     }
 }
 
+impl ZeroPage {
+    /// Unpacks the enclosed address from a Zeropage into a corresponding u8
+    /// address.
+    pub fn unwrap(self) -> u8 {
+        self.into()
+    }
+}
+
+impl From<ZeroPage> for u8 {
+    fn from(src: ZeroPage) -> Self {
+        src.0
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPageIndexedWithX(pub u8);
 
@@ -73,6 +87,20 @@ impl Offset for ZeroPageIndexedWithX {}
 impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithX> for ZeroPageIndexedWithX {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], ZeroPageIndexedWithX> {
         any_byte().map(ZeroPageIndexedWithX).parse(input)
+    }
+}
+
+impl ZeroPageIndexedWithX {
+    /// Unpacks the enclosed address from a ZeropageIndexedWithX into a
+    /// corresponding u8 address.
+    pub fn unwrap(self) -> u8 {
+        self.into()
+    }
+}
+
+impl From<ZeroPageIndexedWithX> for u8 {
+    fn from(src: ZeroPageIndexedWithX) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -41,6 +41,7 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
         parcel::one_of(vec![
             parcel::parsers::byte::expect_byte(0x8d),
             parcel::parsers::byte::expect_byte(0x85),
+            parcel::parsers::byte::expect_byte(0x95),
         ])
         .map(|_| STA)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -919,13 +919,44 @@ fn should_generate_zeropage_address_mode_sta_machine_code() {
         mc
     );
 
-    // validate mops -> vector looks correct
     assert_eq!(
         vec![
             vec![],
             vec![],
             vec![
                 Microcode::WriteMemory(WriteMemory::new(0x01, 0x00)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_zeropage_with_x_index_address_mode_sta_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::STA, address_mode::ZeroPageIndexedWithX(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
                 gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
             ]
         ],

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -156,7 +156,13 @@ fn should_parse_absolute_address_mode_sta_instruction() {
 
 #[test]
 fn should_parse_zeropage_address_mode_sta_instruction() {
-    let bytecode = [0x85, 0x34, 0x12];
+    let bytecode = [0x85, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_zeropage_with_x_index_address_mode_sta_instruction() {
+    let bytecode = [0x95, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -436,6 +436,19 @@ fn should_cycle_on_sta_zeropage_operation() {
 }
 
 #[test]
+fn should_cycle_on_sta_zeropage_with_x_index_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x95, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+
+    let state = cpu.run(4).unwrap();
+
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0x05));
+}
+
+#[test]
 fn should_cycle_on_tax_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xaa])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))


### PR DESCRIPTION
# Introduction
This PR implements the STA Zeropage indexed with X instruction for the mos6502 processor.
# Linked Issues
#39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
