### PR TITLE
Implement unwrap method for the Relative address mode

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -116,10 +116,12 @@ impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithY> for ZeroPageIndexedWithY {
     }
 }
 
+/// Relative wraps an i8 and signifies a relative address to the current
+/// instruction. This is commonly used alongside branch instructions that may
+/// cause a short jump either forward or back in memory to facilitate looping.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Relative(pub i8);
 
-impl Cyclable for Relative {}
 impl Offset for Relative {}
 
 impl<'a> Parser<'a, &'a [u8], Relative> for Relative {
@@ -130,6 +132,20 @@ impl<'a> Parser<'a, &'a [u8], Relative> for Relative {
                 Relative(offset)
             })
             .parse(input)
+    }
+}
+
+impl Relative {
+    /// Unpacks the enclosed address from a Relative addressmode into a
+    /// corresponding i8 address.
+    pub fn unwrap(self) -> i8 {
+        self.into()
+    }
+}
+
+impl From<Relative> for i8 {
+    fn from(src: Relative) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -400,7 +400,7 @@ gen_instruction_cycles_and_parser!(mnemonic::BCC, address_mode::Relative, 0x90, 
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::BCC, address_mode::Relative> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::Relative(offset) = self.address_mode;
+        let offset = self.address_mode.unwrap();
 
         branch_on_case(!cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
     }
@@ -412,7 +412,7 @@ gen_instruction_cycles_and_parser!(mnemonic::BCS, address_mode::Relative, 0xb0, 
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::BCS, address_mode::Relative> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::Relative(offset) = self.address_mode;
+        let offset = self.address_mode.unwrap();
 
         branch_on_case(cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
     }
@@ -424,7 +424,7 @@ gen_instruction_cycles_and_parser!(mnemonic::BEQ, address_mode::Relative, 0xf0, 
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::BEQ, address_mode::Relative> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::Relative(offset) = self.address_mode;
+        let offset = self.address_mode.unwrap();
 
         branch_on_case(cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
     }
@@ -436,7 +436,7 @@ gen_instruction_cycles_and_parser!(mnemonic::BNE, address_mode::Relative, 0xd0, 
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::BNE, address_mode::Relative> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::Relative(offset) = self.address_mode;
+        let offset = self.address_mode.unwrap();
 
         branch_on_case(!cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
     }


### PR DESCRIPTION
# Introduction
This PR simplifies address unpacking for Relative address modes by switching to an unwrap method to expose the enclosed i8 value of the address mode directly.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
