### PR TITLE
Implement STA AbsoluteIndexedWithX instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -166,12 +166,28 @@ impl<'a> Parser<'a, &'a [u8], Indirect> for Indirect {
     }
 }
 
+/// AbsoluteIndexedWithX represents an address whose value is stored at an X
+/// register offset from the operand value. Example being LL + X, HH + X + 1.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithX(pub u16);
 
 impl Offset for AbsoluteIndexedWithX {
     fn offset(&self) -> usize {
         2
+    }
+}
+
+impl AbsoluteIndexedWithX {
+    /// Unpacks the enclosed address from a AbsoluteIndexedWithX addressmode into a
+    /// corresponding u16 address.
+    pub fn unwrap(self) -> u16 {
+        self.into()
+    }
+}
+
+impl From<AbsoluteIndexedWithX> for u16 {
+    fn from(src: AbsoluteIndexedWithX) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -42,6 +42,7 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
             parcel::parsers::byte::expect_byte(0x8d),
             parcel::parsers::byte::expect_byte(0x85),
             parcel::parsers::byte::expect_byte(0x95),
+            parcel::parsers::byte::expect_byte(0x9d),
         ])
         .map(|_| STA)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -905,6 +905,39 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_with_x_index_address_mode_sta_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::STA, address_mode::AbsoluteIndexedWithX(0x0000)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            5,
+            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
 fn should_generate_zeropage_address_mode_sta_machine_code() {
     let cpu = MOS6502::default();
     let op: Operation = Instruction::new(mnemonic::STA, address_mode::ZeroPage(0x01)).into();

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -155,6 +155,12 @@ fn should_parse_absolute_address_mode_sta_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_x_address_mode_sta_instruction() {
+    let bytecode = [0x9d, 0x34, 0x12];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_address_mode_sta_instruction() {
     let bytecode = [0x85, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -424,6 +424,25 @@ fn should_cycle_on_sta_absolute_operation() {
 }
 
 #[test]
+fn should_cycle_on_sta_absolute_indexed_with_x_operation() {
+    let (ram_start, ram_end) = (0x0200, 0x5fff);
+    let cpu = generate_test_cpu_with_instructions(vec![0x9d, 0x00, 0x02])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x5))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .register_address_space(
+            ram_start..=ram_end,
+            Memory::<ReadWrite>::new(ram_start, ram_end),
+        )
+        .unwrap();
+
+    let state = cpu.run(5).unwrap();
+
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0x0205));
+}
+
+#[test]
 fn should_cycle_on_sta_zeropage_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x85, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
Implement the STA AbsoluteIndexedWithX instruction for the mos6502 assembler. This also updates existing AbsoluteIndexedWithX instructions to use the new `unwrap()` method to unpack the address mode.
# Linked Issues
#39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
