### PR TITLE
Implement STA absolute indexed with y instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -167,7 +167,7 @@ impl<'a> Parser<'a, &'a [u8], Indirect> for Indirect {
 }
 
 /// AbsoluteIndexedWithX represents an address whose value is stored at an X
-/// register offset from the operand value. Example being LL + X, HH + X + 1.
+/// register offset from the operand value. Example being LLHH + X.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithX(pub u16);
 
@@ -178,8 +178,8 @@ impl Offset for AbsoluteIndexedWithX {
 }
 
 impl AbsoluteIndexedWithX {
-    /// Unpacks the enclosed address from a AbsoluteIndexedWithX addressmode into a
-    /// corresponding u16 address.
+    /// Unpacks the enclosed address from a AbsoluteIndexedWithX address mode
+    /// into a corresponding u16 address.
     pub fn unwrap(self) -> u16 {
         self.into()
     }
@@ -199,6 +199,8 @@ impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithX> for AbsoluteIndexedWithX {
     }
 }
 
+/// AbsoluteIndexedWithY represents an address whose value is stored at an Y
+/// register offset from the operand value. Example being LLHH + Y.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithY(pub u16);
 
@@ -213,6 +215,20 @@ impl<'a> Parser<'a, &'a [u8], AbsoluteIndexedWithY> for AbsoluteIndexedWithY {
         parcel::take_n(any_byte(), 2)
             .map(|b| AbsoluteIndexedWithY(u16::from_le_bytes([b[0], b[1]])))
             .parse(input)
+    }
+}
+
+impl AbsoluteIndexedWithY {
+    /// Unpacks the enclosed address from a AbsoluteIndexedWithY address mode
+    /// into a corresponding u16 address.
+    pub fn unwrap(self) -> u16 {
+        self.into()
+    }
+}
+
+impl From<AbsoluteIndexedWithY> for u16 {
+    fn from(src: AbsoluteIndexedWithY) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -2,7 +2,7 @@ extern crate parcel;
 use crate::cpu::Offset;
 use parcel::{ParseResult, Parser};
 
-// Load-Store
+// Load operand into Accumulator
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDA;
 
@@ -31,6 +31,7 @@ pub struct LDX;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDY;
 
+// Store Accumulator in memory
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct STA;
 
@@ -43,6 +44,7 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
             parcel::parsers::byte::expect_byte(0x85),
             parcel::parsers::byte::expect_byte(0x95),
             parcel::parsers::byte::expect_byte(0x9d),
+            parcel::parsers::byte::expect_byte(0x99),
         ])
         .map(|_| STA)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -938,6 +938,39 @@ fn should_generate_absolute_with_x_index_address_mode_sta_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_with_y_index_address_mode_sta_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::STA, address_mode::AbsoluteIndexedWithY(0x0000)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            5,
+            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
 fn should_generate_zeropage_address_mode_sta_machine_code() {
     let cpu = MOS6502::default();
     let op: Operation = Instruction::new(mnemonic::STA, address_mode::ZeroPage(0x01)).into();

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -161,6 +161,12 @@ fn should_parse_absolute_indexed_with_x_address_mode_sta_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_y_address_mode_sta_instruction() {
+    let bytecode = [0x99, 0x34, 0x12];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_address_mode_sta_instruction() {
     let bytecode = [0x85, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -443,6 +443,25 @@ fn should_cycle_on_sta_absolute_indexed_with_x_operation() {
 }
 
 #[test]
+fn should_cycle_on_sta_absolute_indexed_with_y_operation() {
+    let (ram_start, ram_end) = (0x0200, 0x5fff);
+    let cpu = generate_test_cpu_with_instructions(vec![0x99, 0x00, 0x02])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x5))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .register_address_space(
+            ram_start..=ram_end,
+            Memory::<ReadWrite>::new(ram_start, ram_end),
+        )
+        .unwrap();
+
+    let state = cpu.run(5).unwrap();
+
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0x0205));
+}
+
+#[test]
 fn should_cycle_on_sta_zeropage_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x85, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
Implement the STA absolute indexed with y instruction for the mos6502 processor. This PR also includes update to other Absolute Indexed with Y instructions to leverage the helper methods for dereferencing addresses and unpacking address modes.

# Linked Issues
#39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
