### PR TITLE
Implement STA X-Indexed Indirect Instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -232,6 +232,9 @@ impl From<AbsoluteIndexedWithY> for u16 {
     }
 }
 
+/// XIndexedIndirect represents an address whose value is stored as an X
+/// register offset for sequential bytes of an address word. Example being
+/// LL + X, LL + X + 1.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct XIndexedIndirect(pub u8);
 
@@ -240,6 +243,20 @@ impl Offset for XIndexedIndirect {}
 impl<'a> Parser<'a, &'a [u8], XIndexedIndirect> for XIndexedIndirect {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], XIndexedIndirect> {
         any_byte().map(XIndexedIndirect).parse(input)
+    }
+}
+
+impl XIndexedIndirect {
+    /// Unpacks the enclosed address from a XIndexedIndirect address mode into
+    /// a corresponding u address.
+    pub fn unwrap(self) -> u8 {
+        self.into()
+    }
+}
+
+impl From<XIndexedIndirect> for u8 {
+    fn from(src: XIndexedIndirect) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -45,6 +45,7 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
             parcel::parsers::byte::expect_byte(0x95),
             parcel::parsers::byte::expect_byte(0x9d),
             parcel::parsers::byte::expect_byte(0x99),
+            parcel::parsers::byte::expect_byte(0x81),
         ])
         .map(|_| STA)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -127,6 +127,15 @@ fn add_indirect_to_address(addr: u16, indirect: u8) -> u16 {
     addr.overflowing_add(indirect as u16).0
 }
 
+fn dereference_indexed_indirect_address(cpu: &MOS6502, base_addr: u8, indirect: u8) -> u16 {
+    u16::from_le_bytes([
+        cpu.address_map
+            .read(base_addr.overflowing_add(indirect).0 as u16),
+        cpu.address_map
+            .read(base_addr.overflowing_add(indirect + 1).0 as u16),
+    ])
+}
+
 /// Provides a wrapper around the common operation of dereferencing and address
 /// mode and retrieving the value stored at the specified address from the
 /// address map. This value is then returned in a wrapper Operand.
@@ -276,6 +285,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithY::default()),
+            inst_to_operation!(mnemonic::STA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::SEC, address_mode::Implied),
@@ -762,13 +772,8 @@ gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::XIndexedIndirect
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::XIndexedIndirect> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::XIndexedIndirect(addr) = self.address_mode;
-        let x = cpu.x.read();
-        let zpage_base_addr = addr as u16 + x as u16;
-        let indirect_addr = u16::from_le_bytes([
-            cpu.address_map.read(zpage_base_addr),
-            cpu.address_map.read(zpage_base_addr + 1),
-        ]);
+        let indirect_addr =
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
         let value = Operand::new(cpu.address_map.read(indirect_addr));
 
         MOps::new(
@@ -907,6 +912,21 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::Absolu
             self.offset(),
             self.cycles(),
             vec![gen_write_memory_microcode!(indexed_addr, acc_val)],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::XIndexedIndirect, 0x81, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::XIndexedIndirect> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let indirect_addr =
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
+        let acc_val = cpu.acc.read();
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_write_memory_microcode!(indirect_addr, acc_val)],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -167,6 +167,12 @@ fn should_parse_absolute_indexed_with_y_address_mode_sta_instruction() {
 }
 
 #[test]
+fn should_parse_x_indexed_indirect_address_mode_sta_instruction() {
+    let bytecode = [0x81, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_address_mode_sta_instruction() {
     let bytecode = [0x85, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -462,6 +462,21 @@ fn should_cycle_on_sta_absolute_indexed_with_y_operation() {
 }
 
 #[test]
+fn should_cycle_on_sta_x_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x81, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+
+    let state = cpu.run(6).unwrap();
+
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0xff));
+}
+
+#[test]
 fn should_cycle_on_sta_zeropage_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x85, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
Implement STA X-Indexed Indirect instruction for the mos6502 processor. This also implements an indexed indirect method helper to assist with dereferencing x indexed indirect addresses along with implementing an unwrap method for the `XIndexedIndirect` address mode.

# Linked Issues
#39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
