### PR TITLE
Implement STA Indirect Y-Indexed Instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -248,7 +248,7 @@ impl<'a> Parser<'a, &'a [u8], XIndexedIndirect> for XIndexedIndirect {
 
 impl XIndexedIndirect {
     /// Unpacks the enclosed address from a XIndexedIndirect address mode into
-    /// a corresponding u address.
+    /// a corresponding u8 address.
     pub fn unwrap(self) -> u8 {
         self.into()
     }
@@ -260,6 +260,9 @@ impl From<XIndexedIndirect> for u8 {
     }
 }
 
+/// IndirectYIndexed represents an address whose value is stored as a Y
+/// register offset for an indirect address defined as the operand. Example
+/// being (LL, LL + 1) + Y.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct IndirectYIndexed(pub u8);
 
@@ -268,5 +271,19 @@ impl Offset for IndirectYIndexed {}
 impl<'a> Parser<'a, &'a [u8], IndirectYIndexed> for IndirectYIndexed {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], IndirectYIndexed> {
         any_byte().map(IndirectYIndexed).parse(input)
+    }
+}
+
+impl IndirectYIndexed {
+    /// Unpacks the enclosed address from a IndirectYIndexed address mode into
+    /// a corresponding u8 address.
+    pub fn unwrap(self) -> u8 {
+        self.into()
+    }
+}
+
+impl From<IndirectYIndexed> for u8 {
+    fn from(src: IndirectYIndexed) -> Self {
+        src.0
     }
 }

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -46,6 +46,7 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
             parcel::parsers::byte::expect_byte(0x9d),
             parcel::parsers::byte::expect_byte(0x99),
             parcel::parsers::byte::expect_byte(0x81),
+            parcel::parsers::byte::expect_byte(0x91),
         ])
         .map(|_| STA)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -123,26 +123,39 @@ impl Add for Operand<u8> {
 /// Provides a wrapper around the operation of unpacking an address mode and
 /// adding an indirect offset to it. This appropriately handles for overflow
 /// and returns the address as a u16.
-fn add_indirect_to_address(addr: u16, indirect: u8) -> u16 {
-    addr.overflowing_add(indirect as u16).0
+fn add_index_to_address(addr: u16, index: u8) -> u16 {
+    addr.overflowing_add(index as u16).0
 }
 
-fn dereference_indexed_indirect_address(cpu: &MOS6502, base_addr: u8, indirect: u8) -> u16 {
+/// Provides a wrapper around the common operation of dereferencing an indexed
+/// indirect address. This is effectively taking the value at
+/// (Operand + Index, addr at Operand + Index + 1).
+fn dereference_indexed_indirect_address(cpu: &MOS6502, base_addr: u8, index: u8) -> u16 {
     u16::from_le_bytes([
         cpu.address_map
-            .read(base_addr.overflowing_add(indirect).0 as u16),
+            .read(base_addr.overflowing_add(index).0 as u16),
         cpu.address_map
-            .read(base_addr.overflowing_add(indirect + 1).0 as u16),
+            .read(base_addr.overflowing_add(index + 1).0 as u16),
     ])
+}
+
+/// Provides a wrapper around the operation of dereferencing an indirect
+/// address and then adding an index to that indirect address. This is
+/// effectively the value at (Operand, Operand + 1) + Index.
+fn dereference_indirect_indexed_address(cpu: &MOS6502, base_addr: u8, index: u8) -> u16 {
+    u16::from_le_bytes([
+        cpu.address_map.read(base_addr as u16),
+        cpu.address_map.read(base_addr.overflowing_add(1).0 as u16),
+    ]) + index as u16
 }
 
 /// Provides a wrapper around the common operation of dereferencing and address
 /// mode and retrieving the value stored at the specified address from the
 /// address map. This value is then returned in a wrapper Operand.
-fn dereference_address_to_operand(cpu: &MOS6502, addr: u16, indirect: u8) -> Operand<u8> {
+fn dereference_address_to_operand(cpu: &MOS6502, addr: u16, index: u8) -> Operand<u8> {
     Operand::new(
         cpu.address_map
-            .read(add_indirect_to_address(addr as u16, indirect)),
+            .read(add_index_to_address(addr as u16, index)),
     )
 }
 
@@ -286,6 +299,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithY::default()),
             inst_to_operation!(mnemonic::STA, address_mode::XIndexedIndirect::default()),
+            inst_to_operation!(mnemonic::STA, address_mode::IndirectYIndexed::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::SEC, address_mode::Implied),
@@ -719,7 +733,7 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
     fn generate(self, cpu: &MOS6502) -> MOps {
         let addr = self.address_mode.unwrap();
         let index = cpu.x.read();
-        let indexed_addr = add_indirect_to_address(addr, index);
+        let indexed_addr = add_index_to_address(addr, index);
         let value = dereference_address_to_operand(cpu, addr, index);
 
         // if the branch crosses a page boundary pay a 1 cycle penalty.
@@ -746,7 +760,7 @@ gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::AbsoluteIndexedW
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::AbsoluteIndexedWithY> {
     fn generate(self, cpu: &MOS6502) -> MOps {
         let addr = self.address_mode.unwrap();
-        let indexed_addr = add_indirect_to_address(addr, cpu.y.read());
+        let indexed_addr = add_index_to_address(addr, cpu.y.read());
         let value = dereference_address_to_operand(cpu, indexed_addr, 0);
 
         // if the branch crosses a page boundary pay a 1 cycle penalty.
@@ -892,7 +906,7 @@ gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::AbsoluteIndexedW
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::AbsoluteIndexedWithX> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let indexed_addr = add_indirect_to_address(self.address_mode.unwrap(), cpu.x.read());
+        let indexed_addr = add_index_to_address(self.address_mode.unwrap(), cpu.x.read());
         let acc_val = cpu.acc.read();
         MOps::new(
             self.offset(),
@@ -906,7 +920,7 @@ gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::AbsoluteIndexedW
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::AbsoluteIndexedWithY> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let indexed_addr = add_indirect_to_address(self.address_mode.unwrap(), cpu.y.read());
+        let indexed_addr = add_index_to_address(self.address_mode.unwrap(), cpu.y.read());
         let acc_val = cpu.acc.read();
         MOps::new(
             self.offset(),
@@ -922,6 +936,21 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::XIndex
     fn generate(self, cpu: &MOS6502) -> MOps {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
+        let acc_val = cpu.acc.read();
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_write_memory_microcode!(indirect_addr, acc_val)],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::IndirectYIndexed, 0x91, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::IndirectYIndexed> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let indirect_addr =
+            dereference_indirect_indexed_address(cpu, self.address_mode.unwrap(), cpu.y.read());
         let acc_val = cpu.acc.read();
         MOps::new(
             self.offset(),
@@ -950,7 +979,7 @@ gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::ZeroPageIndexedW
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::ZeroPageIndexedWithX> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let indexed_addr = add_indirect_to_address(self.address_mode.unwrap() as u16, cpu.x.read());
+        let indexed_addr = add_index_to_address(self.address_mode.unwrap() as u16, cpu.x.read());
         let acc_val = cpu.acc.read();
 
         MOps::new(

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -908,21 +908,18 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
 
 #[test]
 fn should_generate_absolute_with_x_index_address_mode_sta_machine_code() {
-    let mut cpu = MOS6502::default()
-        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
-        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    cpu.address_map.write(0x05, 0xff).unwrap();
-    cpu.address_map.write(0x06, 0x00).unwrap();
-
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     let op: Operation =
-        Instruction::new(mnemonic::STA, address_mode::XIndexedIndirect(0x00)).into();
+        Instruction::new(mnemonic::STA, address_mode::AbsoluteIndexedWithX(0x0000)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
         MOps::new(
-            2,
-            6,
-            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
+            3,
+            5,
+            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
         ),
         mc
     );
@@ -933,10 +930,9 @@ fn should_generate_absolute_with_x_index_address_mode_sta_machine_code() {
             vec![],
             vec![],
             vec![],
-            vec![],
             vec![
-                Microcode::WriteMemory(WriteMemory::new(0xff, 0xff)),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -978,18 +974,21 @@ fn should_generate_absolute_with_y_index_address_mode_sta_machine_code() {
 
 #[test]
 fn should_generate_x_indexed_indirect_address_mode_sta_machine_code() {
-    let cpu = MOS6502::default()
-        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
-        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+
     let op: Operation =
-        Instruction::new(mnemonic::STA, address_mode::AbsoluteIndexedWithY(0x0000)).into();
+        Instruction::new(mnemonic::STA, address_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
         MOps::new(
-            3,
-            5,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
+            2,
+            6,
+            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
         ),
         mc
     );
@@ -1000,9 +999,47 @@ fn should_generate_x_indexed_indirect_address_mode_sta_machine_code() {
             vec![],
             vec![],
             vec![],
+            vec![],
             vec![
-                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
+                Microcode::WriteMemory(WriteMemory::new(0xff, 0xff)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_indirect_y_indexed_address_mode_sta_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+
+    let op: Operation =
+        Instruction::new(mnemonic::STA, address_mode::IndirectYIndexed(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
+        ),
+        mc
+    );
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteMemory(WriteMemory::new(0xff, 0xff)),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -173,6 +173,12 @@ fn should_parse_x_indexed_indirect_address_mode_sta_instruction() {
 }
 
 #[test]
+fn should_parse_indirect_y_indexed_address_mode_sta_instruction() {
+    let bytecode = [0x91, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_address_mode_sta_instruction() {
     let bytecode = [0x85, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -477,6 +477,21 @@ fn should_cycle_on_sta_x_indexed_indirect_operation() {
 }
 
 #[test]
+fn should_cycle_on_sta_y_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x91, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+
+    let state = cpu.run(6).unwrap();
+
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0xff));
+}
+
+#[test]
 fn should_cycle_on_sta_zeropage_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x85, 0x02])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
This PR implements the STA Indirect Y-Indexed instruction for the mos6502 processor while also introducing a helper method for unwrapping the `IndirectYIndexed` address mode. In addition this also includes a helper method for handling the indirect dereferencing of addresses with an index.
# Linked Issues
#39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
