### PR TITLE
Implment PHA implied intruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -311,9 +311,22 @@ impl<'a> Parser<'a, &'a [u8], TXS> for TXS {
 }
 
 // Stack Operations
+
+/// Push Accumulator on stack
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHA;
 
+impl Offset for PHA {}
+
+impl<'a> Parser<'a, &'a [u8], PHA> for PHA {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], PHA> {
+        parcel::parsers::byte::expect_byte(0x48)
+            .map(|_| PHA)
+            .parse(input)
+    }
+}
+
+/// Pull Accumulator from stack
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLA;
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -809,6 +809,45 @@ fn should_generate_implied_address_mode_nop_machine_code() {
     )
 }
 
+// PHA
+
+#[test]
+fn should_generate_implied_address_mode_pha_machine_code() {
+    let cpu = MOS6502::default()
+        .reset()
+        .unwrap()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    let op: Operation = Instruction::new(mnemonic::PHA, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            3,
+            vec![
+                gen_write_memory_microcode!(0x01ff, 0xff),
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+            ]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![
+                // should write to the top of the stack
+                gen_write_memory_microcode!(0x01ff, 0xff),
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // SEC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -143,6 +143,12 @@ fn should_parse_absolute_address_mode_jmp_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_pha_instruction() {
+    let bytecode = [0x48, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sec_instruction() {
     let bytecode = [0x38, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -407,6 +407,16 @@ fn should_cycle_on_nop_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_pha_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x48])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xff, state.address_map.read(0x01ff));
+}
+
+#[test]
 fn should_cycle_on_sec_implied_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x38]);
     cpu.ps.carry = false;


### PR DESCRIPTION
# Introduction
This PR implements the PHA Implied address mode instruction for the mos6502 along with some additional helpers and changes to better handle for over and underflowing of the CPUs registers.
# Linked Issues
#43 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
