### PR TITLE
Implement CMP ZeroPage instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -67,6 +67,7 @@ impl<'a> Parser<'a, &'a [u8], Absolute> for Absolute {
     }
 }
 
+// ZeroPage wraps a u8 and represents an address in 00LL format.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPage(pub u8);
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -149,6 +149,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
         parcel::one_of(vec![
             parcel::parsers::byte::expect_byte(0xc9),
             parcel::parsers::byte::expect_byte(0xcd),
+            parcel::parsers::byte::expect_byte(0xc5),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -371,6 +371,34 @@ fn should_generate_absolute_address_mode_cmp_machine_code() {
     )
 }
 
+#[test]
+fn should_generate_zeropage_address_mode_cmp_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
+    let op: Operation = Instruction::new(mnemonic::CMP, address_mode::ZeroPage::default()).into();
+    let mc = op.generate(&cpu);
+    let expected_mops = vec![
+        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+    ];
+
+    assert_eq!(MOps::new(2, 3, expected_mops.clone()), mc);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            expected_mops
+                .clone()
+                .into_iter()
+                .chain(vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)].into_iter())
+                .collect()
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // INC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -71,6 +71,12 @@ fn should_parse_absolute_address_mode_cmp_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_address_mode_cmp_instruction() {
+    let bytecode = [0xc5, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inc_instruction() {
     let bytecode = [0xee, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -243,6 +243,38 @@ fn should_cycle_on_cmp_absolute_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_zeropage_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xc5, 0xff]).with_gp_register(
+        register::GPRegister::ACC,
+        register::GeneralPurpose::with_value(0x00),
+    );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_zeropage_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xc5, 0xff]).with_gp_register(
+        register::GPRegister::ACC,
+        register::GeneralPurpose::with_value(0xff),
+    );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
 fn should_cycle_on_inc_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xee, 0xff, 0x01]);
 


### PR DESCRIPTION
# Introduction
Implement CMP ZeroPage address mode instruction for the mos6502 processor
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
