### PR TITLE
Implement the CMP ZeroPage,X instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -67,7 +67,7 @@ impl<'a> Parser<'a, &'a [u8], Absolute> for Absolute {
     }
 }
 
-// ZeroPage wraps a u8 and represents an address in 00LL format.
+/// ZeroPage wraps a u8 and represents an address in 00LL format.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPage(pub u8);
 
@@ -94,6 +94,8 @@ impl From<ZeroPage> for u8 {
     }
 }
 
+/// ZeroPageIndexedWithX wraps a u8 and represents an address in the zeropage +
+/// the value of the X register in the format of `00LL + x`.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPageIndexedWithX(pub u8);
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -150,6 +150,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
             parcel::parsers::byte::expect_byte(0xc9),
             parcel::parsers::byte::expect_byte(0xcd),
             parcel::parsers::byte::expect_byte(0xc5),
+            parcel::parsers::byte::expect_byte(0xd5),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -768,10 +768,9 @@ gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::ZeroPageIndexedW
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::ZeroPageIndexedWithX> {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        let address_mode::ZeroPageIndexedWithX(addr) = self.address_mode;
-        let x = cpu.x.read();
-        let indirect_value = cpu.address_map.read((addr + x) as u16);
-        let value = Operand::new(indirect_value);
+        let base_addr = self.address_mode.unwrap() as u16;
+        let index = cpu.x.read();
+        let value = dereference_address_to_operand(cpu, base_addr, index);
 
         MOps::new(
             self.offset(),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -290,6 +290,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPage::default()),
+            inst_to_operation!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
             inst_to_operation!(mnemonic::INY, address_mode::Implied),
@@ -588,6 +589,28 @@ gen_instruction_cycles_and_parser!(mnemonic::CMP, address_mode::ZeroPage, 0xc5, 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::ZeroPage> {
     fn generate(self, cpu: &MOS6502) -> MOps {
         let rhs = dereference_address_to_operand(cpu, self.address_mode.unwrap() as u16, 0);
+        let lhs = Operand::new(cpu.acc.read());
+        let carry = lhs >= rhs;
+        let diff = lhs - rhs;
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX, 0xd5, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::ZeroPageIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let rhs = dereference_address_to_operand(cpu, self.address_mode.unwrap() as u16, index);
         let lhs = Operand::new(cpu.acc.read());
         let carry = lhs >= rhs;
         let diff = lhs - rhs;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -399,6 +399,37 @@ fn should_generate_zeropage_address_mode_cmp_machine_code() {
     )
 }
 
+#[test]
+fn should_generate_zeropage_indexed_with_x_address_mode_cmp_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()).into();
+    let mc = op.generate(&cpu);
+    let expected_mops = vec![
+        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+    ];
+
+    assert_eq!(MOps::new(2, 4, expected_mops.clone()), mc);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            expected_mops
+                .clone()
+                .into_iter()
+                .chain(vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)].into_iter())
+                .collect()
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // INC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -71,6 +71,12 @@ fn should_parse_absolute_address_mode_cmp_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_indexed_with_x_address_mode_cmp_instruction() {
+    let bytecode = [0xd5, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_address_mode_cmp_instruction() {
     let bytecode = [0xc5, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -275,6 +275,48 @@ fn should_cycle_on_cmp_zeropage_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_zeropage_indexed_with_x_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd5, 0xfa])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0x00),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_zeropage_indexed_with_x_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd5, 0xfa])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
 fn should_cycle_on_inc_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xee, 0xff, 0x01]);
 


### PR DESCRIPTION
# Introduction
This PR implements the CMP ZeroPage,X instruction for the mos6502 processor.
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
