### PR TITLE
implement cmp absolute indexed with x instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -151,6 +151,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
             parcel::parsers::byte::expect_byte(0xcd),
             parcel::parsers::byte::expect_byte(0xc5),
             parcel::parsers::byte::expect_byte(0xd5),
+            parcel::parsers::byte::expect_byte(0xdd),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -372,6 +372,37 @@ fn should_generate_absolute_address_mode_cmp_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_indexed_with_x_address_mode_cmp_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
+    let op: Operation =
+        Instruction::new(mnemonic::CMP, address_mode::AbsoluteIndexedWithX::default()).into();
+    let mc = op.generate(&cpu);
+    let expected_mops = vec![
+        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+    ];
+
+    assert_eq!(MOps::new(3, 4, expected_mops.clone()), mc);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            expected_mops
+                .clone()
+                .into_iter()
+                .chain(vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)].into_iter())
+                .collect()
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
 fn should_generate_zeropage_address_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -71,6 +71,12 @@ fn should_parse_absolute_address_mode_cmp_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_x_address_mode_cmp_instruction() {
+    let bytecode = [0xdd, 0x34, 0x12];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_indexed_with_x_address_mode_cmp_instruction() {
     let bytecode = [0xd5, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -227,6 +227,48 @@ fn should_cycle_on_cmp_absolute_operation_with_inequal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_absolute_indexed_with_x_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xdd, 0xfa, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0x00),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_absolute_indexed_with_x_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xdd, 0xfa, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
 fn should_cycle_on_cmp_absolute_operation_with_equal_operands() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xcd, 0xff, 0x00]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This pr introduces the cmp absolute indexed with x instruction for the mos6502 processor. Along with helper changes for both the absolute and zeropage indexed address modes.
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
