### PR TITLE
Implement CMP Absolute Indexed With Y instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -152,6 +152,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
             parcel::parsers::byte::expect_byte(0xc5),
             parcel::parsers::byte::expect_byte(0xd5),
             parcel::parsers::byte::expect_byte(0xdd),
+            parcel::parsers::byte::expect_byte(0xd9),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -297,6 +297,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithX::default()),
+            inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithY::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
@@ -610,6 +611,38 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::Absolu
         } else {
             0
         };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::CMP, address_mode::AbsoluteIndexedWithY, 0xd9, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::AbsoluteIndexedWithY> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.y.read();
+        let base_addr = self.address_mode.unwrap();
+        let indexed_addr = add_index_to_address(base_addr, index);
+        let rhs = dereference_address_to_operand(cpu, indexed_addr, 0);
+        let lhs = Operand::new(cpu.acc.read());
+        let carry = lhs >= rhs;
+        let diff = lhs - rhs;
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(base_addr).contains(indexed_addr) {
+            1
+        } else {
+            0
+        };
+
         MOps::new(
             self.offset(),
             self.cycles() + branch_penalty,

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -403,6 +403,37 @@ fn should_generate_absolute_indexed_with_x_address_mode_cmp_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_indexed_with_y_address_mode_cmp_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
+    let op: Operation =
+        Instruction::new(mnemonic::CMP, address_mode::AbsoluteIndexedWithY::default()).into();
+    let mc = op.generate(&cpu);
+    let expected_mops = vec![
+        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+    ];
+
+    assert_eq!(MOps::new(3, 4, expected_mops.clone()), mc);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            expected_mops
+                .clone()
+                .into_iter()
+                .chain(vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)].into_iter())
+                .collect()
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
 fn should_generate_zeropage_address_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -77,6 +77,12 @@ fn should_parse_absolute_indexed_with_x_address_mode_cmp_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_y_address_mode_cmp_instruction() {
+    let bytecode = [0xd9, 0x34, 0x12];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_indexed_with_x_address_mode_cmp_instruction() {
     let bytecode = [0xd5, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -269,6 +269,48 @@ fn should_cycle_on_cmp_absolute_indexed_with_x_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_absolute_indexed_with_y_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd9, 0xfa, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0x00),
+        )
+        .with_gp_register(
+            register::GPRegister::Y,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_absolute_indexed_with_y_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd9, 0xfa, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GPRegister::Y,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
 fn should_cycle_on_cmp_absolute_operation_with_equal_operands() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xcd, 0xff, 0x00]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This PR implements the CMP Absolute Indexed With Y instruction for the mos6502 processor.
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
