### PR TITLE
Implement CMP X-Indexed Indirect instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -153,6 +153,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
             parcel::parsers::byte::expect_byte(0xd5),
             parcel::parsers::byte::expect_byte(0xdd),
             parcel::parsers::byte::expect_byte(0xd9),
+            parcel::parsers::byte::expect_byte(0xc1),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -298,6 +298,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CMP, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithY::default()),
+            inst_to_operation!(mnemonic::CMP, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
@@ -646,6 +647,30 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::Absolu
         MOps::new(
             self.offset(),
             self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::CMP, address_mode::XIndexedIndirect, 0xc1, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::XIndexedIndirect> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let indirect_addr =
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), index);
+        let rhs = dereference_address_to_operand(cpu, indirect_addr, 0);
+        let lhs = Operand::new(cpu.acc.read());
+        let carry = lhs >= rhs;
+        let diff = lhs - rhs;
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -434,6 +434,33 @@ fn should_generate_absolute_indexed_with_y_address_mode_cmp_machine_code() {
 }
 
 #[test]
+fn should_generate_x_indexed_indirect_address_mode_cmp_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xea));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::CMP, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_zeropage_address_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -83,6 +83,12 @@ fn should_parse_absolute_indexed_with_y_address_mode_cmp_instruction() {
 }
 
 #[test]
+fn should_parse_indirect_indexed_with_x_address_mode_cmp_instruction() {
+    let bytecode = [0xd9, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_zeropage_indexed_with_x_address_mode_cmp_instruction() {
     let bytecode = [0xd5, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -327,6 +327,52 @@ fn should_cycle_on_cmp_absolute_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_x_indexed_indirect_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xc1, 0x01, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xea),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x06, 0xff).unwrap();
+    cpu.address_map.write(0x07, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_x_indexed_indirect_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xc1, 0x01, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GPRegister::X,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x06, 0xff).unwrap();
+    cpu.address_map.write(0x07, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_cmp_zeropage_operation_with_inequal_operands() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xc5, 0xff]).with_gp_register(
         register::GPRegister::ACC,


### PR DESCRIPTION
# Introduction
This PR mplements the CMP X-Indexed Indirect instruction for the mos6502 processor
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
