### PR TITLE
Implement CMP IndirectYIndexed Instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -154,6 +154,7 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
             parcel::parsers::byte::expect_byte(0xdd),
             parcel::parsers::byte::expect_byte(0xd9),
             parcel::parsers::byte::expect_byte(0xc1),
+            parcel::parsers::byte::expect_byte(0xd1),
         ])
         .map(|_| CMP)
         .parse(input)

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -298,6 +298,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CMP, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::AbsoluteIndexedWithY::default()),
+            inst_to_operation!(mnemonic::CMP, address_mode::IndirectYIndexed::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()),
@@ -312,16 +313,16 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::AbsoluteIndexedWithY::default()),
-            inst_to_operation!(mnemonic::LDA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::IndirectYIndexed::default()),
+            inst_to_operation!(mnemonic::LDA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::PHA, address_mode::Implied),
             inst_to_operation!(mnemonic::PLA, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::STA, address_mode::AbsoluteIndexedWithY::default()),
-            inst_to_operation!(mnemonic::STA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::STA, address_mode::IndirectYIndexed::default()),
+            inst_to_operation!(mnemonic::STA, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::STA, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::SEC, address_mode::Implied),
@@ -639,6 +640,37 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::Absolu
 
         // if the branch crosses a page boundary pay a 1 cycle penalty.
         let branch_penalty = if !Page::from(base_addr).contains(indexed_addr) {
+            1
+        } else {
+            0
+        };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::CMP, address_mode::IndirectYIndexed, 0xd1, 5);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::IndirectYIndexed> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.y.read();
+        let base_addr = self.address_mode.unwrap();
+        let indirect_addr = dereference_indirect_indexed_address(cpu, base_addr, index);
+        let rhs = dereference_address_to_operand(cpu, indirect_addr, 0);
+        let lhs = Operand::new(cpu.acc.read());
+        let carry = lhs >= rhs;
+        let diff = lhs - rhs;
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(base_addr as u16).contains(indirect_addr) {
             1
         } else {
             0

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -987,26 +987,6 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
     }
 }
 
-gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::XIndexedIndirect, 0xa1, 6);
-
-impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::XIndexedIndirect> {
-    fn generate(self, cpu: &MOS6502) -> MOps {
-        let indirect_addr =
-            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
-        let value = Operand::new(cpu.address_map.read(indirect_addr));
-
-        MOps::new(
-            self.offset(),
-            self.cycles(),
-            vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
-            ],
-        )
-    }
-}
-
 gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::IndirectYIndexed, 0xb1, 5);
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::IndirectYIndexed> {
@@ -1026,6 +1006,26 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Indire
         MOps::new(
             self.offset(),
             self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::LDA, address_mode::XIndexedIndirect, 0xa1, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::XIndexedIndirect> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let indirect_addr =
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
+        let value = Operand::new(cpu.address_map.read(indirect_addr));
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
@@ -1176,12 +1176,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::Absolu
     }
 }
 
-gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::XIndexedIndirect, 0x81, 6);
+gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::IndirectYIndexed, 0x91, 6);
 
-impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::XIndexedIndirect> {
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::IndirectYIndexed> {
     fn generate(self, cpu: &MOS6502) -> MOps {
         let indirect_addr =
-            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
+            dereference_indirect_indexed_address(cpu, self.address_mode.unwrap(), cpu.y.read());
         let acc_val = cpu.acc.read();
         MOps::new(
             self.offset(),
@@ -1191,12 +1191,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::XIndex
     }
 }
 
-gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::IndirectYIndexed, 0x91, 6);
+gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::XIndexedIndirect, 0x81, 6);
 
-impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::IndirectYIndexed> {
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::XIndexedIndirect> {
     fn generate(self, cpu: &MOS6502) -> MOps {
         let indirect_addr =
-            dereference_indirect_indexed_address(cpu, self.address_mode.unwrap(), cpu.y.read());
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
         let acc_val = cpu.acc.read();
         MOps::new(
             self.offset(),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -880,49 +880,6 @@ fn should_generate_absolute_indexed_with_y_address_mode_lda_machine_code() {
 }
 
 #[test]
-fn should_generate_x_indexed_indirect_address_mode_lda_machine_code() {
-    let mut cpu =
-        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    cpu.address_map.write(0x05, 0xff).unwrap();
-    cpu.address_map.write(0x06, 0x00).unwrap();
-    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
-
-    let op: Operation =
-        Instruction::new(mnemonic::LDA, address_mode::XIndexedIndirect(0x00)).into();
-    let mc = op.generate(&cpu);
-
-    assert_eq!(
-        MOps::new(
-            2,
-            6,
-            vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea)
-            ]
-        ),
-        mc
-    );
-
-    assert_eq!(
-        vec![
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
-            ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
-    )
-}
-
-#[test]
 fn should_generate_indirect_y_indexed_address_mode_lda_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
@@ -946,22 +903,32 @@ fn should_generate_indirect_y_indexed_address_mode_lda_machine_code() {
         ),
         mc
     );
+}
+
+#[test]
+fn should_generate_x_indexed_indirect_address_mode_lda_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::LDA, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
 
     assert_eq!(
-        vec![
-            vec![],
-            vec![],
-            vec![],
-            vec![],
+        MOps::new(
+            2,
+            6,
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xea)
             ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
-    )
+        ),
+        mc
+    );
 }
 
 // NOP
@@ -1233,43 +1200,6 @@ fn should_generate_absolute_with_y_index_address_mode_sta_machine_code() {
 }
 
 #[test]
-fn should_generate_x_indexed_indirect_address_mode_sta_machine_code() {
-    let mut cpu = MOS6502::default()
-        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
-        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    cpu.address_map.write(0x05, 0xff).unwrap();
-    cpu.address_map.write(0x06, 0x00).unwrap();
-
-    let op: Operation =
-        Instruction::new(mnemonic::STA, address_mode::XIndexedIndirect(0x00)).into();
-    let mc = op.generate(&cpu);
-
-    assert_eq!(
-        MOps::new(
-            2,
-            6,
-            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
-        ),
-        mc
-    );
-
-    assert_eq!(
-        vec![
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![
-                Microcode::WriteMemory(WriteMemory::new(0xff, 0xff)),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
-            ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
-    )
-}
-
-#[test]
 fn should_generate_indirect_y_indexed_address_mode_sta_machine_code() {
     let mut cpu = MOS6502::default()
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05))
@@ -1289,21 +1219,28 @@ fn should_generate_indirect_y_indexed_address_mode_sta_machine_code() {
         ),
         mc
     );
+}
+
+#[test]
+fn should_generate_x_indexed_indirect_address_mode_sta_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+
+    let op: Operation =
+        Instruction::new(mnemonic::STA, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
 
     assert_eq!(
-        vec![
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![
-                Microcode::WriteMemory(WriteMemory::new(0xff, 0xff)),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
-            ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
-    )
+        MOps::new(
+            2,
+            6,
+            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
+        ),
+        mc
+    );
 }
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -434,6 +434,33 @@ fn should_generate_absolute_indexed_with_y_address_mode_cmp_machine_code() {
 }
 
 #[test]
+fn should_generate_indirect_y_indexed_address_mode_cmp_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xea));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::CMP, address_mode::IndirectYIndexed(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_x_indexed_indirect_address_mode_cmp_machine_code() {
     let mut cpu = MOS6502::default()
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -83,14 +83,14 @@ fn should_parse_absolute_indexed_with_y_address_mode_cmp_instruction() {
 }
 
 #[test]
-fn should_parse_x_indexed_indirect_address_mode_cmp_instruction() {
-    let bytecode = [0xc1, 0x34, 0x00];
+fn should_parse_indirect_indexed_with_y_address_mode_cmp_instruction() {
+    let bytecode = [0xd1, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 
 #[test]
-fn should_parse_indirect_indexed_with_y_address_mode_cmp_instruction() {
-    let bytecode = [0xd1, 0x34, 0x00];
+fn should_parse_x_indexed_indirect_address_mode_cmp_instruction() {
+    let bytecode = [0xc1, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 
@@ -161,14 +161,14 @@ fn should_parse_absolute_indexed_with_y_address_mode_lda_instruction() {
 }
 
 #[test]
-fn should_parse_x_indexed_indirect_address_mode_lda_instruction() {
-    let bytecode = [0xa1, 0x12, 0x00];
+fn should_parse_indirect_y_indexed_address_mode_lda_instruction() {
+    let bytecode = [0xb1, 0x12, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 
 #[test]
-fn should_parse_indirect_y_indexed_address_mode_lda_instruction() {
-    let bytecode = [0xb1, 0x12, 0x00];
+fn should_parse_x_indexed_indirect_address_mode_lda_instruction() {
+    let bytecode = [0xa1, 0x12, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 
@@ -227,14 +227,14 @@ fn should_parse_absolute_indexed_with_y_address_mode_sta_instruction() {
 }
 
 #[test]
-fn should_parse_x_indexed_indirect_address_mode_sta_instruction() {
-    let bytecode = [0x81, 0x34, 0x00];
+fn should_parse_indirect_y_indexed_address_mode_sta_instruction() {
+    let bytecode = [0x91, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 
 #[test]
-fn should_parse_indirect_y_indexed_address_mode_sta_instruction() {
-    let bytecode = [0x91, 0x34, 0x00];
+fn should_parse_x_indexed_indirect_address_mode_sta_instruction() {
+    let bytecode = [0x81, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -83,8 +83,14 @@ fn should_parse_absolute_indexed_with_y_address_mode_cmp_instruction() {
 }
 
 #[test]
-fn should_parse_indirect_indexed_with_x_address_mode_cmp_instruction() {
-    let bytecode = [0xd9, 0x34, 0x00];
+fn should_parse_x_indexed_indirect_address_mode_cmp_instruction() {
+    let bytecode = [0xc1, 0x34, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_indirect_indexed_with_y_address_mode_cmp_instruction() {
+    let bytecode = [0xd1, 0x34, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -618,11 +618,11 @@ fn should_cycle_on_lda_absolute_indexed_with_y_operation() {
 }
 
 #[test]
-fn should_cycle_on_lda_x_indexed_indirect_operation() {
-    let mut cpu = generate_test_cpu_with_instructions(vec![0xa1, 0x05])
-        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00));
-    cpu.address_map.write(0x05, 0xff).unwrap();
-    cpu.address_map.write(0x06, 0x00).unwrap();
+fn should_cycle_on_lda_indirect_y_indexed_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb1, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap();
 
     let state = cpu.run(6).unwrap();
@@ -632,11 +632,11 @@ fn should_cycle_on_lda_x_indexed_indirect_operation() {
 }
 
 #[test]
-fn should_cycle_on_lda_indirect_y_indexed_operation() {
-    let mut cpu = generate_test_cpu_with_instructions(vec![0xb1, 0x00])
-        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
-    cpu.address_map.write(0x00, 0xfa).unwrap();
-    cpu.address_map.write(0x01, 0x00).unwrap();
+fn should_cycle_on_lda_x_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xa1, 0x05])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap();
 
     let state = cpu.run(6).unwrap();
@@ -764,12 +764,12 @@ fn should_cycle_on_sta_absolute_indexed_with_y_operation() {
 }
 
 #[test]
-fn should_cycle_on_sta_x_indexed_indirect_operation() {
-    let mut cpu = generate_test_cpu_with_instructions(vec![0x81, 0x00])
-        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+fn should_cycle_on_sta_y_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x91, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05))
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
-    cpu.address_map.write(0x05, 0xff).unwrap();
-    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
 
     let state = cpu.run(6).unwrap();
 
@@ -779,12 +779,12 @@ fn should_cycle_on_sta_x_indexed_indirect_operation() {
 }
 
 #[test]
-fn should_cycle_on_sta_y_indexed_indirect_operation() {
-    let mut cpu = generate_test_cpu_with_instructions(vec![0x91, 0x00])
-        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05))
+fn should_cycle_on_sta_x_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x81, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
-    cpu.address_map.write(0x00, 0xfa).unwrap();
-    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
 
     let state = cpu.run(6).unwrap();
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -327,6 +327,52 @@ fn should_cycle_on_cmp_absolute_operation_with_equal_operands() {
 }
 
 #[test]
+fn should_cycle_on_cmp_indirect_y_indexed_operation_with_equal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd1, 0x01, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xea),
+        )
+        .with_gp_register(
+            register::GPRegister::Y,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x01, 0xfa).unwrap();
+    cpu.address_map.write(0x02, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, true)
+    );
+}
+
+#[test]
+fn should_cycle_on_cmp_indirect_y_indexed_operation_with_inequal_operands() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xd1, 0x01, 0x00])
+        .with_gp_register(
+            register::GPRegister::ACC,
+            register::GeneralPurpose::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GPRegister::Y,
+            register::GeneralPurpose::with_value(0x05),
+        );
+    cpu.address_map.write(0x01, 0xfa).unwrap();
+    cpu.address_map.write(0x02, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xea).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_cmp_x_indexed_indirect_operation_with_equal_operands() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xc1, 0x01, 0x00])
         .with_gp_register(


### PR DESCRIPTION
# Introduction
This PR implements the CMP Indirect, Y-Indexed instruction for the mos6502 processor.
# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
