### PR TITLE
Implment LDX Instructions

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -136,6 +136,8 @@ impl From<ZeroPageIndexedWithX> for u8 {
     }
 }
 
+/// ZeroPageIndexedWithY wraps a u8 and represents an address in the zeropage +
+/// the value of the Y register in the format of `00LL + y`.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPageIndexedWithY(pub u8);
 
@@ -145,6 +147,20 @@ impl Offset for ZeroPageIndexedWithY {}
 impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithY> for ZeroPageIndexedWithY {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], ZeroPageIndexedWithY> {
         any_byte().map(ZeroPageIndexedWithY).parse(input)
+    }
+}
+
+impl ZeroPageIndexedWithY {
+    /// Unpacks the enclosed address from a ZeropageIndexedWithY into a
+    /// corresponding u8 address.
+    pub fn unwrap(self) -> u8 {
+        self.into()
+    }
+}
+
+impl From<ZeroPageIndexedWithY> for u8 {
+    fn from(src: ZeroPageIndexedWithY) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -35,7 +35,10 @@ impl<'a> Parser<'a, &'a [u8], LDX> for LDX {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], LDX> {
         parcel::one_of(vec![
             parcel::parsers::byte::expect_byte(0xa2),
+            parcel::parsers::byte::expect_byte(0xa6),
+            parcel::parsers::byte::expect_byte(0xb6),
             parcel::parsers::byte::expect_byte(0xae),
+            parcel::parsers::byte::expect_byte(0xbe),
         ])
         .map(|_| LDX)
         .parse(input)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -972,6 +972,27 @@ fn should_generate_absolute_address_mode_ldx_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_indexed_with_y_address_mode_ldx_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::LDX, address_mode::AbsoluteIndexedWithY(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::X, 0x00)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_ldx_machine_code() {
     let cpu = MOS6502::default();
     let op: Operation = Instruction::new(mnemonic::LDX, address_mode::Immediate(0xff)).into();
@@ -985,6 +1006,55 @@ fn should_generate_immediate_address_mode_ldx_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_address_mode_ldx_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDX, address_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(
+                    ByteRegisters::X,
+                    0x00 // memory defaults to null
+                )
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_indexed_with_y_address_mode_ldx_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::LDX, address_mode::ZeroPageIndexedWithY(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(
+                    ByteRegisters::X,
+                    0xff // value at 0x05 in memory should be 0xff
+                )
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -179,8 +179,26 @@ fn should_parse_absolute_address_mode_ldx_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_y_address_mode_ldx_instruction() {
+    let bytecode = [0xbe, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_immediate_address_mode_ldx_instruction() {
     let bytecode = [0xa2, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_zeropage_address_mode_ldx_instruction() {
+    let bytecode = [0xa6, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_zeropage_with_y_index_address_mode_lda_instruction() {
+    let bytecode = [0xb6, 0x12, 0x34];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -665,10 +665,44 @@ fn should_cycle_on_ldx_absolute_operation() {
 }
 
 #[test]
+fn should_cycle_on_ldx_absolute_indexed_with_y_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xbe, 0x00, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_ldx_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xa2, 0xff]);
 
     let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
+fn should_cycle_on_ldx_zeropage_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xa6, 0xff]);
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x00, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, true));
+}
+
+#[test]
+fn should_cycle_on_ldx_zeropage_indexed_with_y_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb6, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
     assert_eq!(0x6002, state.pc.read());
     assert_eq!(0xff, state.x.read());
     assert_eq!((state.ps.negative, state.ps.zero), (true, false));


### PR DESCRIPTION
# Introduction
This PR implements the Zeropage, ZeroPage with Y Index and Absolute with Y Index address modes for the LDX mnemonic for the mos6502 processor.
# Linked Issues
#76 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
