### PR TITLE
Implement LDY instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -25,7 +25,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
     }
 }
 
-/// Load operand into X-Register
+/// Load operand into X Register
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDX;
 
@@ -45,8 +45,25 @@ impl<'a> Parser<'a, &'a [u8], LDX> for LDX {
     }
 }
 
+/// Load operand into Y Register
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDY;
+
+impl Offset for LDY {}
+
+impl<'a> Parser<'a, &'a [u8], LDY> for LDY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], LDY> {
+        parcel::one_of(vec![
+            parcel::parsers::byte::expect_byte(0xa0),
+            parcel::parsers::byte::expect_byte(0xa4),
+            parcel::parsers::byte::expect_byte(0xb4),
+            parcel::parsers::byte::expect_byte(0xac),
+            parcel::parsers::byte::expect_byte(0xbc),
+        ])
+        .map(|_| LDY)
+        .parse(input)
+    }
+}
 
 // Store Accumulator in memory
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1061,6 +1061,118 @@ fn should_generate_zeropage_indexed_with_y_address_mode_ldx_machine_code() {
     );
 }
 
+// LDY
+
+#[test]
+fn should_generate_absolute_address_mode_ldy_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDY, address_mode::Absolute(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_x_address_mode_ldy_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    let op: Operation =
+        Instruction::new(mnemonic::LDY, address_mode::AbsoluteIndexedWithX(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_immediate_address_mode_ldy_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDY, address_mode::Immediate(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_address_mode_ldy_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDY, address_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                gen_write_8bit_register_microcode!(
+                    ByteRegisters::Y,
+                    0x00 // memory defaults to null
+                )
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_indexed_with_x_address_mode_ldy_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::LDY, address_mode::ZeroPageIndexedWithX(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(
+                    ByteRegisters::Y,
+                    0xff // value at 0x05 in memory should be 0xff
+                )
+            ]
+        ),
+        mc
+    );
+}
+
 // NOP
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -197,8 +197,38 @@ fn should_parse_zeropage_address_mode_ldx_instruction() {
 }
 
 #[test]
-fn should_parse_zeropage_with_y_index_address_mode_lda_instruction() {
+fn should_parse_zeropage_with_y_index_address_mode_ldx_instruction() {
     let bytecode = [0xb6, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_absolute_address_mode_ldy_instruction() {
+    let bytecode = [0xac, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_absolute_indexed_with_x_address_mode_ldy_instruction() {
+    let bytecode = [0xbc, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_immediate_address_mode_ldy_instruction() {
+    let bytecode = [0xa0, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_zeropage_address_mode_ldy_instruction() {
+    let bytecode = [0xa4, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_zeropage_with_x_index_address_mode_ldy_instruction() {
+    let bytecode = [0xb4, 0x12, 0x34];
     gen_op_parse_assertion!(&bytecode);
 }
 


### PR DESCRIPTION
# Introduction
This PR implements all LDY instruction address modes for the mos6502 processor.
# Linked Issues
#75 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
