### PR TITLE
Implment PHP Implied Instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -366,7 +366,7 @@ impl<'a> Parser<'a, &'a [u8], PHA> for PHA {
     }
 }
 
-/// Pull Accumulator from stack
+/// Pull Accumulator from stack.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLA;
 
@@ -380,8 +380,19 @@ impl<'a> Parser<'a, &'a [u8], PLA> for PLA {
     }
 }
 
+/// Push Status Register to stack.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHP;
+
+impl Offset for PHP {}
+
+impl<'a> Parser<'a, &'a [u8], PHP> for PHP {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], PHP> {
+        parcel::parsers::byte::expect_byte(0x08)
+            .map(|_| PHP)
+            .parse(input)
+    }
+}
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLP;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1219,6 +1219,32 @@ fn should_generate_implied_address_mode_pha_machine_code() {
     )
 }
 
+// PHP
+
+#[test]
+fn should_generate_implied_address_mode_php_machine_code() {
+    let cpu = MOS6502::default()
+        .reset()
+        .unwrap()
+        .with_ps_register(ProcessorStatus::with_value(0x55));
+    let op: Operation = Instruction::new(mnemonic::PHP, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![
+                // should write to the top of the stack
+                gen_write_memory_microcode!(0x01ff, 0x55),
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // PLA
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -245,6 +245,12 @@ fn should_parse_implied_address_mode_pha_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_php_instruction() {
+    let bytecode = [0x08, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_pla_instruction() {
     let bytecode = [0x68, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -793,6 +793,16 @@ fn should_cycle_on_pha_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_php_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x08])
+        .with_ps_register(register::ProcessorStatus::with_value(0x55));
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x55, state.address_map.read(0x01ff));
+}
+
+#[test]
 fn should_cycle_on_pla_implied_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x68])
         // simulate having pushed teh value 0xff to the stack


### PR DESCRIPTION
# Introduction
This PR implements the PHP Implied Address Mode instruction for the mos6502 processor.
# Linked Issues
#48 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
