### PR TITLE
Implment PLP Implied Instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -380,7 +380,7 @@ impl<'a> Parser<'a, &'a [u8], PLA> for PLA {
     }
 }
 
-/// Push Status Register to stack.
+/// Push Processor Status to stack.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHP;
 
@@ -394,8 +394,19 @@ impl<'a> Parser<'a, &'a [u8], PHP> for PHP {
     }
 }
 
+// Pull Processor Status from stack.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLP;
+
+impl Offset for PLP {}
+
+impl<'a> Parser<'a, &'a [u8], PLP> for PLP {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], PLP> {
+        parcel::parsers::byte::expect_byte(0x28)
+            .map(|_| PLP)
+            .parse(input)
+    }
+}
 
 // Subroutines and Jump
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1276,6 +1276,35 @@ fn should_generate_implied_address_mode_pla_machine_code() {
     )
 }
 
+// PLP
+
+#[test]
+fn should_generate_implied_address_mode_plp_machine_code() {
+    let mut cpu = MOS6502::default()
+        .reset()
+        .unwrap()
+        // simulate having pushed the value 0x55 from ps register to the stack
+        .with_sp_register(StackPointer::with_value(0xfe));
+    cpu.address_map.write(0x01ff, 0x55).unwrap();
+
+    let op: Operation = Instruction::new(mnemonic::PLP, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                gen_inc_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_write_8bit_register_microcode!(ByteRegisters::PS, 0x55),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // SEC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -257,6 +257,12 @@ fn should_parse_implied_address_mode_pla_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_plp_instruction() {
+    let bytecode = [0x28, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sec_instruction() {
     let bytecode = [0x38, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -805,7 +805,7 @@ fn should_cycle_on_php_implied_operation() {
 #[test]
 fn should_cycle_on_pla_implied_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x68])
-        // simulate having pushed teh value 0xff to the stack
+        // simulate having pushed the value 0xff to the stack
         .with_sp_register(register::StackPointer::with_value(0xfe));
     cpu.address_map.write(0x01ff, 0xff).unwrap();
 
@@ -813,6 +813,18 @@ fn should_cycle_on_pla_implied_operation() {
     assert_eq!(0x6001, state.pc.read());
     assert_eq!(0xff, state.acc.read());
     assert_eq!((true, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
+fn should_cycle_on_plp_implied_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x28])
+        // simulate having pushed the value 0x55 from ps register to stack
+        .with_sp_register(register::StackPointer::with_value(0xfe));
+    cpu.address_map.write(0x01ff, 0x55).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x55, state.ps.read());
 }
 
 #[test]


### PR DESCRIPTION
# Introduction
This PR implements the PLP Implied address mode instruction for the mos6502 processor
# Linked Issues
#55 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
