### PR TITLE
Implement DEX Implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -145,6 +145,16 @@ pub struct DEC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEX;
 
+impl Offset for DEX {}
+
+impl<'a> Parser<'a, &'a [u8], DEX> for DEX {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], DEX> {
+        parcel::parsers::byte::expect_byte(0xca)
+            .map(|_| DEX)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEY;
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -142,6 +142,7 @@ impl<'a> Parser<'a, &'a [u8], INY> for INY {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEC;
 
+/// Decrement X register by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEX;
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -546,10 +546,32 @@ fn should_generate_zeropage_indexed_with_x_address_mode_cmp_machine_code() {
     )
 }
 
+// DEX
+
+#[test]
+fn should_generate_implied_address_mode_dex_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::DEX, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
+            ]
+        ),
+        mc
+    );
+}
+
 // INC
 
 #[test]
-fn should_generate_implied_address_mode_inc_machine_code() {
+fn should_generate_absolute_address_mode_inc_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x01ff, 0x05).unwrap();
     let op: Operation = Instruction::new(mnemonic::INC, address_mode::Absolute(0x01ff)).into();

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -107,7 +107,13 @@ fn should_parse_zeropage_address_mode_cmp_instruction() {
 }
 
 #[test]
-fn should_parse_implied_address_mode_inc_instruction() {
+fn should_parse_implied_address_mode_dex_instruction() {
+    let bytecode = [0xca, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_absolute_address_mode_inc_instruction() {
     let bytecode = [0xee, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -493,7 +493,18 @@ fn should_cycle_on_cmp_zeropage_indexed_with_x_operation_with_equal_operands() {
 }
 
 #[test]
-fn should_cycle_on_inc_implied_operation() {
+fn should_cycle_on_dex_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xca])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x51));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x50, state.x.read());
+    assert_eq!((false, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
+fn should_cycle_on_inc_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xee, 0xff, 0x01]);
 
     let state = cpu.run(6).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the DEX Implied address mode instruction for the mos6502 processor.
# Linked Issues
#86 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
