### PR TITLE
Implement DEY Implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -156,8 +156,19 @@ impl<'a> Parser<'a, &'a [u8], DEX> for DEX {
     }
 }
 
+/// Decrement Y register by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEY;
+
+impl Offset for DEY {}
+
+impl<'a> Parser<'a, &'a [u8], DEY> for DEY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], DEY> {
+        parcel::parsers::byte::expect_byte(0x88)
+            .map(|_| DEY)
+            .parse(input)
+    }
+}
 
 // Shift and Rotate
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -303,6 +303,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::CMP, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::DEX, address_mode::Implied),
+            inst_to_operation!(mnemonic::DEY, address_mode::Implied),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
             inst_to_operation!(mnemonic::INY, address_mode::Implied),
@@ -784,6 +785,26 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::DEX, address_mode::Implie
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
+            ],
+        )
+    }
+}
+
+// DEY
+
+gen_instruction_cycles_and_parser!(mnemonic::DEY, address_mode::Implied, 0x88, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::DEY, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.x.read()) - Operand::new(1);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -568,6 +568,28 @@ fn should_generate_implied_address_mode_dex_machine_code() {
     );
 }
 
+// DEY
+
+#[test]
+fn should_generate_implied_address_mode_dey_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::DEY, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
+            ]
+        ),
+        mc
+    );
+}
+
 // INC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -113,6 +113,12 @@ fn should_parse_implied_address_mode_dex_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_dey_instruction() {
+    let bytecode = [0x88, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_inc_instruction() {
     let bytecode = [0xee, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -504,6 +504,17 @@ fn should_cycle_on_dex_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_dey_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x88])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0xff));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xfe, state.y.read());
+    assert_eq!((true, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
 fn should_cycle_on_inc_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xee, 0xff, 0x01]);
 


### PR DESCRIPTION
# Introduction
This PR implements the DEY Implied address mode instruction for the mos6502 processor.
# Linked Issues
#70 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
