### PR TITLE
Implement INC AbsoluteX instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -68,16 +68,19 @@ pub struct ADC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SBC;
 
+/// Increment Memory by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INC;
 
-generate_mnemonic_parser_and_offset!(INC, 0xee);
+generate_mnemonic_parser_and_offset!(INC, 0xee, 0xfe);
 
+/// Increment X register by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INX;
 
 generate_mnemonic_parser_and_offset!(INX, 0xe8);
 
+/// Increment Y register by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INY;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -306,6 +306,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::DEX, address_mode::Implied),
             inst_to_operation!(mnemonic::DEY, address_mode::Implied),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
+            inst_to_operation!(mnemonic::INC, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
             inst_to_operation!(mnemonic::INY, address_mode::Implied),
             inst_to_operation!(mnemonic::JMP, address_mode::Absolute::default()),
@@ -848,6 +849,27 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::INC, address_mode::Absolu
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_memory_microcode!(addr, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::INC, address_mode::AbsoluteIndexedWithX, 0xfe, 7);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::INC, address_mode::AbsoluteIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let addr = self.address_mode.unwrap();
+        let indexed_addr = add_index_to_address(addr, index);
+        let value = dereference_address_to_operand(cpu, indexed_addr, 0) + Operand::new(1);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -636,6 +636,29 @@ fn should_generate_absolute_address_mode_inc_machine_code() {
     );
 }
 
+#[test]
+fn should_generate_absolute_indexed_by_x_address_mode_inc_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x01ff, 0x05).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::INC, address_mode::AbsoluteIndexedWithX(0x01fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            7,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x01ff, 0x06),
+            ]
+        ),
+        mc
+    );
+}
+
 // INX
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -131,6 +131,12 @@ fn should_parse_absolute_address_mode_inc_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_by_x_address_mode_inc_instruction() {
+    let bytecode = [0xfe, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inx_instruction() {
     let bytecode = [0xe8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -535,6 +535,17 @@ fn should_cycle_on_inc_absolute_operation() {
 }
 
 #[test]
+fn should_cycle_on_inc_absolute_indexed_with_x_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xfe, 0xfa, 0x01])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+
+    let state = cpu.run(7).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(1, state.address_map.read(0x01ff));
+    assert_eq!((false, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
 fn should_cycle_on_inx_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xe8])
         .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(127));


### PR DESCRIPTION
# Introduction
This PR implements the INC Absolute indexed with X instruction for the mos6502 processor.
# Linked Issues
#91 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
