### PR TITLE
Implement INC ZeroPage Instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -72,7 +72,7 @@ pub struct SBC;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INC;
 
-generate_mnemonic_parser_and_offset!(INC, 0xee, 0xfe);
+generate_mnemonic_parser_and_offset!(INC, 0xee, 0xfe, 0xe6);
 
 /// Increment X register by one.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -307,6 +307,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::DEY, address_mode::Implied),
             inst_to_operation!(mnemonic::INC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::INC, address_mode::AbsoluteIndexedWithX::default()),
+            inst_to_operation!(mnemonic::INC, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
             inst_to_operation!(mnemonic::INY, address_mode::Implied),
             inst_to_operation!(mnemonic::JMP, address_mode::Absolute::default()),
@@ -870,6 +871,25 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::INC, address_mode::Absolu
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::INC, address_mode::ZeroPage, 0xe6, 5);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::INC, address_mode::ZeroPage> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let addr = self.address_mode.unwrap() as u16;
+        let value = dereference_address_to_operand(cpu, addr, 0) + Operand::new(1);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(addr, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -659,6 +659,27 @@ fn should_generate_absolute_indexed_by_x_address_mode_inc_machine_code() {
     );
 }
 
+#[test]
+fn should_generate_zeropage_address_mode_inc_machine_code() {
+    let mut cpu = MOS6502::default();
+    cpu.address_map.write(0xff, 0x05).unwrap();
+    let op: Operation = Instruction::new(mnemonic::INC, address_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0xff, 0x06),
+            ]
+        ),
+        mc
+    );
+}
+
 // INX
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -137,6 +137,12 @@ fn should_parse_absolute_indexed_by_x_address_mode_inc_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_inc_instruction() {
+    let bytecode = [0xe6, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_inx_instruction() {
     let bytecode = [0xe8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -546,6 +546,16 @@ fn should_cycle_on_inc_absolute_indexed_with_x_operation() {
 }
 
 #[test]
+fn should_cycle_on_inc_zeropage_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xe6, 0xff]);
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(1, state.address_map.read(0xff));
+    assert_eq!((false, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
 fn should_cycle_on_inx_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xe8])
         .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(127));


### PR DESCRIPTION
# Introduction
This PR implements the INC ZeroPage address mode instruction for the mos6502 cpu.
# Linked Issues
#91 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
