### PR TITLE
Implement AND Immediate Instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -117,8 +117,11 @@ pub struct ROL;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROR;
 
+/// And Memory with Accumulator.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
+
+generate_mnemonic_parser_and_offset!(AND, 0x29);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1,14 +1,39 @@
 use crate::address_map::Addressable;
-use crate::cpu::mos6502::{
-    microcode::*,
-    operations::{address_mode, mnemonic, Instruction, MOps, Operation},
-    register::{
-        ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter,
-        ProgramStatusFlags, StackPointer, WordRegisters,
+use crate::cpu::{
+    mos6502::{
+        microcode::*,
+        operations::{address_mode, mnemonic, Instruction, MOps, Operation},
+        register::{
+            ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter,
+            ProgramStatusFlags, StackPointer, WordRegisters,
+        },
+        Generate, MOS6502,
     },
-    Generate, MOS6502,
+    register::Register,
 };
-use crate::cpu::register::Register;
+
+// AND
+
+#[test]
+fn should_generate_immediate_address_mode_and_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    let op: Operation = Instruction::new(mnemonic::AND, address_mode::Immediate(0x55)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
 
 // BCC
 

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -11,6 +11,12 @@ macro_rules! gen_op_parse_assertion {
 }
 
 #[test]
+fn should_parse_immediate_address_mode_and_instruction() {
+    let bytecode = [0x29, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_relative_address_mode_bcc_instruction() {
     let bytecode = [0x90, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,6 +27,17 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn should_cycle_on_add_immediate_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x29, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x55));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
 fn bcc_implied_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
     cpu.ps.carry = false;


### PR DESCRIPTION
# Introduction
This PR implements the AND Immediate address mode instruction for the mos6502 processor.
# Linked Issues
#52 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
