### PR TITLE
Implement AND Absolute instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -121,7 +121,7 @@ pub struct ROR;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
 
-generate_mnemonic_parser_and_offset!(AND, 0x29);
+generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -15,6 +15,28 @@ use crate::cpu::{
 // AND
 
 #[test]
+fn should_generate_absolute_address_mode_and_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation = Instruction::new(mnemonic::AND, address_mode::Absolute(0x00ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_and_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -11,6 +11,12 @@ macro_rules! gen_op_parse_assertion {
 }
 
 #[test]
+fn should_parse_absolute_address_mode_and_instruction() {
+    let bytecode = [0x2d, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_immediate_address_mode_and_instruction() {
     let bytecode = [0x29, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,9 +27,21 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn should_cycle_on_add_absolute_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x2d, 0xff, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
 fn should_cycle_on_add_immediate_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0x29, 0xff])
-        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x55));
+    let cpu = generate_test_cpu_with_instructions(vec![0x29, 0x55])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
 
     let state = cpu.run(2).unwrap();
     assert_eq!(0x6002, state.pc.read());


### PR DESCRIPTION
# Introduction
Implement the AND Absolute address mode instruction for the mos6502 processor.
# Linked Issues
#52 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
