### PR TITLE
Implement AND ZeroPage instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -121,7 +121,7 @@ pub struct ROR;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
 
-generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d);
+generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d, 0x25);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -296,6 +296,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Immediate::default()),
+            inst_to_operation!(mnemonic::AND, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::BCC, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BCS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
@@ -469,6 +470,26 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::Immedi
     fn generate(self, cpu: &MOS6502) -> MOps {
         let rhs = Operand::new(cpu.acc.read());
         let lhs = Operand::new(self.address_mode.unwrap());
+        let value = rhs & lhs;
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::ZeroPage, 0x25, 3);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::ZeroPage> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let rhs = Operand::new(cpu.acc.read());
+        let lhs = dereference_address_to_operand(cpu, self.address_mode.unwrap() as u16, 0);
         let value = rhs & lhs;
 
         MOps::new(

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -57,6 +57,28 @@ fn should_generate_immediate_address_mode_and_machine_code() {
     );
 }
 
+#[test]
+fn should_generate_zeropage_address_mode_and_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation = Instruction::new(mnemonic::AND, address_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
 // BCC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -23,6 +23,12 @@ fn should_parse_immediate_address_mode_and_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_address_mode_and_instruction() {
+    let bytecode = [0x25, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_relative_address_mode_bcc_instruction() {
     let bytecode = [0x90, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -50,6 +50,18 @@ fn should_cycle_on_add_immediate_operation() {
 }
 
 #[test]
+fn should_cycle_on_add_zeropage_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x25, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
 fn bcc_implied_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
     cpu.ps.carry = false;


### PR DESCRIPTION
# Introduction
This PR implements the AND ZeroPage address mode instruction for the mos6502 processor
# Linked Issues
#52 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
