### PR TITLE
Implement ADD Absolute indexed instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -121,7 +121,7 @@ pub struct ROR;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
 
-generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d, 0x25, 0x35);
+generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d, 0x3d, 0x39, 0x25, 0x35);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -295,6 +295,8 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
+            inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
+            inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithY::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::AND, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::AND, address_mode::ZeroPageIndexedWithX::default()),
@@ -456,6 +458,66 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::Absolu
         MOps::new(
             self.offset(),
             self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::AbsoluteIndexedWithX, 0x3d, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::AbsoluteIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let addr = self.address_mode.unwrap();
+        let indexed_addr = add_index_to_address(addr, index);
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = dereference_address_to_operand(cpu, addr, index);
+        let value = lhs & rhs;
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(addr).contains(indexed_addr) {
+            1
+        } else {
+            0
+        };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::AbsoluteIndexedWithY, 0x39, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::AbsoluteIndexedWithY> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.y.read();
+        let addr = self.address_mode.unwrap();
+        let indexed_addr = add_index_to_address(addr, index);
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = dereference_address_to_operand(cpu, addr, index);
+        let value = lhs & rhs;
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(addr).contains(indexed_addr) {
+            1
+        } else {
+            0
+        };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -37,6 +37,54 @@ fn should_generate_absolute_address_mode_and_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_indexed_with_x_address_mode_and_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::AND, address_mode::AbsoluteIndexedWithX(0x00fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_y_address_mode_and_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::AND, address_mode::AbsoluteIndexedWithY(0x00fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_and_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -17,6 +17,18 @@ fn should_parse_absolute_address_mode_and_instruction() {
 }
 
 #[test]
+fn should_parse_absolute_indexed_with_x_address_mode_and_instruction() {
+    let bytecode = [0x3d, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_absolute_indexed_with_y_address_mode_and_instruction() {
+    let bytecode = [0x39, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_immediate_address_mode_and_instruction() {
     let bytecode = [0x29, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -39,6 +39,32 @@ fn should_cycle_on_add_absolute_operation() {
 }
 
 #[test]
+fn should_cycle_on_add_absolute_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x3d, 0xfa, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
+fn should_cycle_on_add_absolute_indexed_with_y_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x39, 0xfa, 0x00])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05))
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
 fn should_cycle_on_add_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x29, 0x55])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
This PR implements the ADD Absolute indexed address mode instructions for the mos6502 processor.
# Linked Issues
#52
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
