### PR TITLE
Implment ADD Indexed Indirect instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -121,7 +121,7 @@ pub struct ROR;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
 
-generate_mnemonic_parser_and_offset!(AND, 0x29, 0x2d, 0x3d, 0x39, 0x25, 0x35);
+generate_mnemonic_parser_and_offset!(AND, 0x2d, 0x3d, 0x21, 0x29, 0x39, 0x25, 0x35);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -297,7 +297,9 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithY::default()),
+            inst_to_operation!(mnemonic::AND, address_mode::IndirectYIndexed::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Immediate::default()),
+            inst_to_operation!(mnemonic::AND, address_mode::XIndexedIndirect::default()),
             inst_to_operation!(mnemonic::AND, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::AND, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::BCC, address_mode::Relative::default()),
@@ -527,12 +529,64 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::Absolu
     }
 }
 
+gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::IndirectYIndexed, 0x31, 5);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::IndirectYIndexed> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let zpage_base_addr = self.address_mode.unwrap();
+        let indirect_addr =
+            dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = Operand::new(cpu.address_map.read(indirect_addr));
+        let value = lhs & rhs;
+
+        // if the branch crosses a page boundary pay a 1 cycle penalty.
+        let branch_penalty = if !Page::from(zpage_base_addr as u16).contains(indirect_addr) {
+            1
+        } else {
+            0
+        };
+
+        MOps::new(
+            self.offset(),
+            self.cycles() + branch_penalty,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
 gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::Immediate, 0x29, 2);
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::Immediate> {
     fn generate(self, cpu: &MOS6502) -> MOps {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.address_mode.unwrap());
+        let value = lhs & rhs;
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::AND, address_mode::XIndexedIndirect, 0x21, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::AND, address_mode::XIndexedIndirect> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let indirect_addr =
+            dereference_indexed_indirect_address(cpu, self.address_mode.unwrap(), cpu.x.read());
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = Operand::new(cpu.address_map.read(indirect_addr));
         let value = lhs & rhs;
 
         MOps::new(

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -85,6 +85,33 @@ fn should_generate_absolute_indexed_with_y_address_mode_and_machine_code() {
 }
 
 #[test]
+fn should_generate_indirect_y_indexed_address_mode_and_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::AND, address_mode::IndirectYIndexed(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_and_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
@@ -95,6 +122,33 @@ fn should_generate_immediate_address_mode_and_machine_code() {
         MOps::new(
             2,
             2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_x_indexed_indirect_address_mode_and_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::AND, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -29,8 +29,20 @@ fn should_parse_absolute_indexed_with_y_address_mode_and_instruction() {
 }
 
 #[test]
+fn should_parse_indirect_y_indexed_address_mode_and_instruction() {
+    let bytecode = [0x31, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_immediate_address_mode_and_instruction() {
     let bytecode = [0x29, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_x_indexed_indirect_address_mode_and_instruction() {
+    let bytecode = [0x21, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -65,11 +65,41 @@ fn should_cycle_on_add_absolute_indexed_with_y_operation() {
 }
 
 #[test]
+fn should_cycle_on_and_indirect_y_indexed_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x31, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x55).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
 fn should_cycle_on_add_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x29, 0x55])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
 
     let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
+}
+
+#[test]
+fn should_cycle_on_add_x_indexed_indirect_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x21, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x55).unwrap();
+
+    let state = cpu.run(6).unwrap();
     assert_eq!(0x6002, state.pc.read());
     assert_eq!(0x55, state.acc.read());
     assert_eq!((state.ps.negative, state.ps.zero), (false, false));


### PR DESCRIPTION
# Introduction
This PR implements the ADD Indexed Indirect and Indirect Indexed instructions for the mos6502 processor.
# Linked Issues
#52 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
