### PR TITLE
Switch generated Instruction parser to use unboxed parser.

### DIFF
--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -481,6 +481,8 @@ macro_rules! gen_instruction_cycles_and_parser {
                 &self,
                 input: &'a [u8],
             ) -> ParseResult<&'a [u8], Instruction<$mnemonic, $address_mode>> {
+                // If the expected opcode and address mode match, map it to a
+                // corresponding Instruction.
                 parcel::map(
                     parcel::and_then(expect_byte($opcode), |_| <$address_mode>::default()),
                     |am| Instruction::new(<$mnemonic>::default(), am),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -481,10 +481,11 @@ macro_rules! gen_instruction_cycles_and_parser {
                 &self,
                 input: &'a [u8],
             ) -> ParseResult<&'a [u8], Instruction<$mnemonic, $address_mode>> {
-                expect_byte($opcode)
-                    .and_then(|_| <$address_mode>::default())
-                    .map(|am| Instruction::new(<$mnemonic>::default(), am))
-                    .parse(input)
+                parcel::map(
+                    parcel::and_then(expect_byte($opcode), |_| <$address_mode>::default()),
+                    |am| Instruction::new(<$mnemonic>::default(), am),
+                )
+                .parse(input)
             }
         }
     };


### PR DESCRIPTION
# Introduction
This small change was to test how much impact using a boxed vs unboxed parser had on performance. To test the impact of this change I've included a before and after run of the basic example with a release build showing an approximately 30% runtime improvement.


before

```
vscode ➜ /workspaces/mainspring (main) $ time cargo run --release --example basic
    Finished release [optimized] target(s) in 0.00s
     Running `target/release/examples/basic`
MOS6502 { address_map: AddressMap [32768..=65535, 256..=511, 32746..=32767, 0..=255], acc: GeneralPurpose { inner: 3 }, x: GeneralPurpose { inner: 0 }, y: GeneralPurpose { inner: 0 }, sp: StackPointer { inner: 255 }, pc: ProgramCounter { inner: 32746 }, ps: ProcessorStatus { carry: false, zero: false, interrupt_disable: false, decimal: false, brk: false, unused: true, overflow: false, negative: false } }

real    0m2.944s
user    0m2.930s
sys     0m0.013s
```

after


```
vscode ➜ /workspaces/mainspring (main ✗) $ time cargo run --release --example basic
    Finished release [optimized] target(s) in 0.00s
     Running `target/release/examples/basic`
MOS6502 { address_map: AddressMap [32768..=65535, 32746..=32767, 256..=511, 0..=255], acc: GeneralPurpose { inner: 3 }, x: GeneralPurpose { inner: 0 }, y: GeneralPurpose { inner: 0 }, sp: StackPointer { inner: 255 }, pc: ProgramCounter { inner: 32746 }, ps: ProcessorStatus { carry: false, zero: false, interrupt_disable: false, decimal: false, brk: false, unused: true, overflow: false, negative: false } }

real    0m1.977s
user    0m1.972s
sys     0m0.004s
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
