### PR TITLE
Implement BVS relative instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -197,8 +197,11 @@ pub struct BMI;
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BVC;
 
+/// Branch on Overflow. Follows branch when the overflow flag is set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BVS;
+
+generate_mnemonic_parser_and_offset!(BVS, 0x70);
 
 // Transfer
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -327,6 +327,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::BCS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BVS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
             inst_to_operation!(mnemonic::CLD, address_mode::Implied),
             inst_to_operation!(mnemonic::CLI, address_mode::Implied),
@@ -1167,6 +1168,18 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::BNE, address_mode::Relati
         let offset = self.address_mode.unwrap();
 
         branch_on_case(!cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
+    }
+}
+
+// BVS
+
+gen_instruction_cycles_and_parser!(mnemonic::BVS, address_mode::Relative, 0x70, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BVS, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let offset = self.address_mode.unwrap();
+
+        branch_on_case(!cpu.ps.overflow, offset, self.offset(), self.cycles(), cpu)
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -425,6 +425,61 @@ fn should_generate_bne_machine_code_with_no_jump() {
     assert_eq!(MOps::new(2, 2, vec![]), mc);
 }
 
+// BVS
+
+#[test]
+fn should_generate_bvs_machine_code_with_branch_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.overflow = false;
+
+    let op: Operation = Instruction::new(mnemonic::BVS, address_mode::Relative(8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.overflow = false;
+
+    let op: Operation = Instruction::new(mnemonic::BVS, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bvs_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.overflow = true;
+
+    let op: Operation = Instruction::new(mnemonic::BVS, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
 // CLC
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -83,6 +83,12 @@ fn should_parse_relative_address_mode_bne_instruction() {
 }
 
 #[test]
+fn should_parse_relative_address_mode_bvs_instruction() {
+    let bytecode = [0x70, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_clc_instruction() {
     let bytecode = [0x18, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -247,6 +247,35 @@ fn bne_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn bvs_implied_operation_should_jump_when_overflow_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0x08]);
+    cpu.ps.overflow = false;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bvs_implied_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0xf8]);
+    cpu.ps.overflow = false;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bvs_implied_operation_should_not_jump_when_overflow_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0x08]);
+    cpu.ps.overflow = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
 fn should_cycle_on_clc_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x18]);
 


### PR DESCRIPTION
# Introduction
This PR Implements the BVS Relative address mode instruction for the mos6502 processor
# Linked Issues
#66 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
