### PR TITLE
Implement BMI Relative instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -191,8 +191,11 @@ generate_mnemonic_parser_and_offset!(BEQ, 0xf0);
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BPL;
 
+/// Branch on negative. Follows branch when the negative flag is set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BMI;
+
+generate_mnemonic_parser_and_offset!(BMI, 30);
 
 /// Branch on Overflow clear. Follows branch when overflow flag is not set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -327,6 +327,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::BCS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BMI, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BVC, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BVS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
@@ -1157,6 +1158,18 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::BEQ, address_mode::Relati
         let offset = self.address_mode.unwrap();
 
         branch_on_case(cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
+    }
+}
+
+// BMI
+
+gen_instruction_cycles_and_parser!(mnemonic::BMI, address_mode::Relative, 0x30, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BMI, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let offset = self.address_mode.unwrap();
+
+        branch_on_case(cpu.ps.negative, offset, self.offset(), self.cycles(), cpu)
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -370,6 +370,61 @@ fn should_generate_beq_machine_code_with_no_jump() {
     assert_eq!(MOps::new(2, 2, vec![]), mc);
 }
 
+// BMI
+
+#[test]
+fn should_generate_bvs_machine_code_with_branch_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = true;
+
+    let op: Operation = Instruction::new(mnemonic::BMI, address_mode::Relative(8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = true;
+
+    let op: Operation = Instruction::new(mnemonic::BMI, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bvs_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = false;
+
+    let op: Operation = Instruction::new(mnemonic::BMI, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
 // BNE
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -131,7 +131,7 @@ fn should_cycle_on_and_zeropage_indexed_with_x_operation() {
 }
 
 #[test]
-fn bcc_implied_operation_should_jump_when_zero_set() {
+fn bcc_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
     cpu.ps.carry = false;
 
@@ -141,7 +141,7 @@ fn bcc_implied_operation_should_jump_when_zero_set() {
 }
 
 #[test]
-fn bcc_implied_operation_should_incur_penalty_at_page_boundary() {
+fn bcc_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0xf8]);
     cpu.ps.carry = false;
 
@@ -151,7 +151,7 @@ fn bcc_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn bcc_implied_operation_should_not_jump_when_zero_unset() {
+fn bcc_relative_operation_should_not_jump_when_zero_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
     cpu.ps.carry = true;
 
@@ -160,7 +160,7 @@ fn bcc_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
-fn bcs_implied_operation_should_jump_when_zero_set() {
+fn bcs_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0x08]);
     cpu.ps.carry = true;
 
@@ -170,7 +170,7 @@ fn bcs_implied_operation_should_jump_when_zero_set() {
 }
 
 #[test]
-fn bcs_implied_operation_should_incur_penalty_at_page_boundary() {
+fn bcs_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0xf8]);
     cpu.ps.carry = true;
 
@@ -180,7 +180,7 @@ fn bcs_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn bcs_implied_operation_should_not_jump_when_zero_unset() {
+fn bcs_relative_operation_should_not_jump_when_zero_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xb0, 0x08]);
     cpu.ps.carry = false;
 
@@ -189,7 +189,7 @@ fn bcs_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
-fn beq_implied_operation_should_jump_when_zero_set() {
+fn beq_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
     cpu.ps.zero = true;
 
@@ -199,7 +199,7 @@ fn beq_implied_operation_should_jump_when_zero_set() {
 }
 
 #[test]
-fn beq_implied_operation_should_incur_penalty_at_page_boundary() {
+fn beq_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0xf8]);
     cpu.ps.zero = true;
 
@@ -209,7 +209,7 @@ fn beq_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn beq_implied_operation_should_not_jump_when_zero_unset() {
+fn beq_relative_operation_should_not_jump_when_zero_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xf0, 0x08]);
     cpu.ps.zero = false;
 
@@ -218,7 +218,36 @@ fn beq_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
-fn bne_implied_operation_should_jump_when_zero_set() {
+fn bmi_relative_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x30, 0x08]);
+    cpu.ps.negative = true;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bmi_relative_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x30, 0xf8]);
+    cpu.ps.negative = true;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bmi_relative_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x30, 0x08]);
+    cpu.ps.negative = false;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
+fn bne_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0x08]);
     cpu.ps.zero = false;
 
@@ -228,7 +257,7 @@ fn bne_implied_operation_should_jump_when_zero_set() {
 }
 
 #[test]
-fn bne_implied_operation_should_incur_penalty_at_page_boundary() {
+fn bne_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0xf8]);
     cpu.ps.zero = false;
 
@@ -238,7 +267,7 @@ fn bne_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn bne_implied_operation_should_not_jump_when_zero_unset() {
+fn bne_relative_operation_should_not_jump_when_zero_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0x08]);
     cpu.ps.zero = true;
 
@@ -247,7 +276,7 @@ fn bne_implied_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
-fn bvc_implied_operation_should_jump_when_overflow_set() {
+fn bvc_relative_operation_should_jump_when_overflow_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x50, 0x08]);
     cpu.ps.overflow = false;
 
@@ -257,7 +286,7 @@ fn bvc_implied_operation_should_jump_when_overflow_set() {
 }
 
 #[test]
-fn bvc_implied_operation_should_incur_penalty_at_page_boundary() {
+fn bvc_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x50, 0xf8]);
     cpu.ps.overflow = false;
 
@@ -267,7 +296,7 @@ fn bvc_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn bvc_implied_operation_should_not_jump_when_overflow_unset() {
+fn bvc_relative_operation_should_not_jump_when_overflow_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x50, 0x08]);
     cpu.ps.overflow = true;
 
@@ -276,7 +305,7 @@ fn bvc_implied_operation_should_not_jump_when_overflow_unset() {
 }
 
 #[test]
-fn bvs_implied_operation_should_jump_when_overflow_set() {
+fn bvs_relative_operation_should_jump_when_overflow_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0x08]);
     cpu.ps.overflow = true;
 
@@ -286,7 +315,7 @@ fn bvs_implied_operation_should_jump_when_overflow_set() {
 }
 
 #[test]
-fn bvs_implied_operation_should_incur_penalty_at_page_boundary() {
+fn bvs_relative_operation_should_incur_penalty_at_page_boundary() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0xf8]);
     cpu.ps.overflow = true;
 
@@ -296,7 +325,7 @@ fn bvs_implied_operation_should_incur_penalty_at_page_boundary() {
 }
 
 #[test]
-fn bvs_implied_operation_should_not_jump_when_overflow_unset() {
+fn bvs_relative_operation_should_not_jump_when_overflow_unset() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x70, 0x08]);
     cpu.ps.overflow = false;
 


### PR DESCRIPTION
# Introduction
This PR implements the BMI Relative address mode instruction for the mo6502 processor
# Linked Issues
#56 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
