### PR TITLE
Implement bpl relative instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -188,8 +188,11 @@ pub struct BEQ;
 
 generate_mnemonic_parser_and_offset!(BEQ, 0xf0);
 
+// Branch on positive. Follows branch when the negative flag is not set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BPL;
+
+generate_mnemonic_parser_and_offset!(BPL, 0x10);
 
 /// Branch on negative. Follows branch when the negative flag is set.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -326,8 +326,9 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::BCC, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BCS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BEQ, address_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BMI, address_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BNE, address_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BPL, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BVC, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::BVS, address_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
@@ -1182,6 +1183,18 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::BNE, address_mode::Relati
         let offset = self.address_mode.unwrap();
 
         branch_on_case(!cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
+    }
+}
+
+// BPL
+
+gen_instruction_cycles_and_parser!(mnemonic::BPL, address_mode::Relative, 0x10, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BPL, address_mode::Relative> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let offset = self.address_mode.unwrap();
+
+        branch_on_case(!cpu.ps.negative, offset, self.offset(), self.cycles(), cpu)
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -373,7 +373,7 @@ fn should_generate_beq_machine_code_with_no_jump() {
 // BMI
 
 #[test]
-fn should_generate_bvs_machine_code_with_branch_penalty() {
+fn should_generate_bmi_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = true;
 
@@ -394,7 +394,7 @@ fn should_generate_bvs_machine_code_with_branch_penalty() {
 }
 
 #[test]
-fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
+fn should_generate_bmi_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = true;
 
@@ -415,7 +415,7 @@ fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
 }
 
 #[test]
-fn should_generate_bvs_machine_code_with_no_jump() {
+fn should_generate_bmi_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = false;
 
@@ -475,6 +475,61 @@ fn should_generate_bne_machine_code_with_no_jump() {
     cpu.ps.zero = true;
 
     let op: Operation = Instruction::new(mnemonic::BNE, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+}
+
+// BPL
+
+#[test]
+fn should_generate_bpl_machine_code_with_branch_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = false;
+
+    let op: Operation = Instruction::new(mnemonic::BPL, address_mode::Relative(8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() + 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bpl_machine_code_with_branch_and_page_penalty() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = false;
+
+    let op: Operation = Instruction::new(mnemonic::BPL, address_mode::Relative(-8)).into();
+    let mc = op.generate(&cpu);
+
+    // pc - relative address - inst size
+    let pc = cpu.pc.read() - 8 - 2;
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_bpl_machine_code_with_no_jump() {
+    let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
+    cpu.ps.negative = true;
+
+    let op: Operation = Instruction::new(mnemonic::BPL, address_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(MOps::new(2, 2, vec![]), mc);

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -1,1 +1,2 @@
-
+#[cfg(test)]
+mod code_generation;

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -276,6 +276,35 @@ fn bne_relative_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn bpl_relative_operation_should_jump_when_zero_set() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x10, 0x08]);
+    cpu.ps.negative = false;
+
+    // 3 cycles with branch penalty
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6008, state.pc.read());
+}
+
+#[test]
+fn bpl_relative_operation_should_incur_penalty_at_page_boundary() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x10, 0xf8]);
+    cpu.ps.negative = false;
+
+    // 4 cycles with branch penalty
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x5ff8, state.pc.read());
+}
+
+#[test]
+fn bpl_relative_operation_should_not_jump_when_zero_unset() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x10, 0x08]);
+    cpu.ps.negative = true;
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+}
+
+#[test]
 fn bvc_relative_operation_should_jump_when_overflow_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x50, 0x08]);
     cpu.ps.overflow = false;


### PR DESCRIPTION
# Introduction
This PR implements the BPL Relative address mode instruction for the mos6502 along with readding the code generation tests that were mistakenly removed along with the parse tests in #183.
# Linked Issues
#49 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
