### PR TITLE
Implement ADC immediate instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -69,8 +69,12 @@ pub struct STY;
 generate_mnemonic_parser_and_offset!(STY, 0x8c, 0x84, 0x94);
 
 // Arithmetic
+
+/// Add Memory to Accumulator with carry.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ADC;
+
+generate_mnemonic_parser_and_offset!(ADC, 0x69);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SBC;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -516,9 +516,9 @@ macro_rules! bit_is_set {
 }
 
 /// This method returns a boolean representing if the addition of two bytes
-/// results in a twos-complimentary overflow. Could be represented by the
-/// following formula (!LHS7 & !RHS7 & C6) || (LHS7 & RHS7 & !C6).
-fn is_an_overflowing_add(lhs: u8, rhs: u8, carry: bool) -> bool {
+/// results in a twos-complement overflow. Could be represented by the following
+/// formula (!LHS7 & !RHS7 & C6) || (LHS7 & RHS7 & !C6).
+fn is_twos_complement_overflowing_add(lhs: u8, rhs: u8, carry: bool) -> bool {
     (!bit_is_set!(lhs, 7) && !bit_is_set!(rhs, 7) && carry)
         || (bit_is_set!(lhs, 7) && bit_is_set!(rhs, 7) && !carry)
 }
@@ -534,7 +534,7 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::Immedi
         let value = lhs + rhs;
 
         // calculate overflow
-        let overflow = is_an_overflowing_add(lhs.unwrap(), rhs.unwrap(), cpu.ps.carry);
+        let overflow = is_twos_complement_overflowing_add(lhs.unwrap(), rhs.unwrap(), cpu.ps.carry);
 
         MOps::new(
             self.offset(),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -51,15 +51,17 @@ impl From<u16> for Page {
 struct Operand<T> {
     carry: bool,
     negative: bool,
+    overflow: bool,
     zero: bool,
     inner: T,
 }
 
 impl<T> Operand<T> {
-    fn with_flags(inner: T, carry: bool, negative: bool, zero: bool) -> Self {
+    fn with_flags(inner: T, carry: bool, negative: bool, overflow: bool, zero: bool) -> Self {
         Self {
             carry,
             negative,
+            overflow,
             zero,
             inner,
         }
@@ -85,6 +87,7 @@ impl Operand<u8> {
         Self {
             carry: false,
             negative: ((inner >> 7) & 1) == 1, // most significant bit set
+            overflow: false,
             zero: inner == 0,
             inner,
         }
@@ -100,7 +103,7 @@ impl std::ops::Add for Operand<u8> {
         let negative = ((sum >> 7) & 1) == 1; // most significant bit set
         let zero = sum == 0;
 
-        Self::with_flags(sum, carry, negative, zero)
+        Self::with_flags(sum, carry, negative, false, zero)
     }
 }
 
@@ -113,7 +116,7 @@ impl std::ops::Sub for Operand<u8> {
         let negative = ((difference >> 7) & 1) == 1; // most significant bit set
         let zero = difference == 0;
 
-        Self::with_flags(difference, carry, negative, zero)
+        Self::with_flags(difference, carry, negative, false, zero)
     }
 }
 
@@ -315,6 +318,7 @@ struct OperationParser;
 impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
+            inst_to_operation!(mnemonic::ADC, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithY::default()),
@@ -504,6 +508,32 @@ macro_rules! gen_instruction_cycles_and_parser {
             }
         }
     };
+}
+
+// Arithmetic Operations
+
+// ADC
+
+gen_instruction_cycles_and_parser!(mnemonic::ADC, address_mode::Immediate, 0x69, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::Immediate> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = Operand::new(self.address_mode.unwrap());
+        let value = lhs + rhs;
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, value.overflow),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
 }
 
 // Bit-wise Operations

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -17,8 +17,8 @@ use crate::cpu::{
 #[test]
 fn should_generate_immediate_address_mode_adc_machine_code() {
     let cpu =
-        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xc0));
-    let op: Operation = Instruction::new(mnemonic::ADC, address_mode::Immediate(0xc4)).into();
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
+    let op: Operation = Instruction::new(mnemonic::ADC, address_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -27,10 +27,10 @@ fn should_generate_immediate_address_mode_adc_machine_code() {
             2,
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x84)
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -12,6 +12,31 @@ use crate::cpu::{
     register::Register,
 };
 
+// ADC
+
+#[test]
+fn should_generate_immediate_address_mode_adc_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xc0));
+    let op: Operation = Instruction::new(mnemonic::ADC, address_mode::Immediate(0xc4)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x84)
+            ]
+        ),
+        mc
+    );
+}
+
 // AND
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,6 +27,44 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn should_cycle_on_adc_immediate_operation_with_overflow() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x69, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_immediate_operation_without_overflow() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x69, 0x50])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_and_absolute_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x2d, 0xff, 0x00])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
This PR Implements the ADC Immediate instruction for the mos6502 processor.

# Linked Issues
#42 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
