### PR TITLE
Implement Remaining ADC Addressing Modes

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -74,7 +74,7 @@ generate_mnemonic_parser_and_offset!(STY, 0x8c, 0x84, 0x94);
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ADC;
 
-generate_mnemonic_parser_and_offset!(ADC, 0x69);
+generate_mnemonic_parser_and_offset!(ADC, 0x6d, 0x7d, 0x79, 0x71, 0x69, 0x61, 0x65, 0x75);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SBC;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -348,6 +348,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::ADC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::ADC, address_mode::Immediate::default()),
+            inst_to_operation!(mnemonic::ADC, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithY::default()),
@@ -573,6 +574,31 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::Immedi
     fn generate(self, cpu: &MOS6502) -> MOps {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.address_mode.unwrap());
+
+        // calculate overflow
+        let (value, overflow) = lhs.twos_complement_add(rhs, cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::ADC, address_mode::ZeroPage, 0x65, 3);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::ZeroPage> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let addr = add_index_to_zeropage_address(self.address_mode.unwrap(), 0);
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = dereference_address_to_operand(cpu, addr, 0);
 
         // calculate overflow
         let (value, overflow) = lhs.twos_complement_add(rhs, cpu.ps.carry);

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -346,6 +346,7 @@ struct OperationParser;
 impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
         parcel::one_of(vec![
+            inst_to_operation!(mnemonic::ADC, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::ADC, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
@@ -541,6 +542,30 @@ macro_rules! gen_instruction_cycles_and_parser {
 // Arithmetic Operations
 
 // ADC
+
+gen_instruction_cycles_and_parser!(mnemonic::ADC, address_mode::Absolute, 0x6d, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::Absolute> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = dereference_address_to_operand(cpu, self.address_mode.unwrap(), 0);
+
+        // calculate overflow
+        let (value, overflow) = lhs.twos_complement_add(rhs, cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
 
 gen_instruction_cycles_and_parser!(mnemonic::ADC, address_mode::Immediate, 0x69, 2);
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -351,6 +351,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::ADC, address_mode::AbsoluteIndexedWithY::default()),
             inst_to_operation!(mnemonic::ADC, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::ADC, address_mode::ZeroPage::default()),
+            inst_to_operation!(mnemonic::ADC, address_mode::ZeroPageIndexedWithX::default()),
             inst_to_operation!(mnemonic::AND, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithX::default()),
             inst_to_operation!(mnemonic::AND, address_mode::AbsoluteIndexedWithY::default()),
@@ -667,6 +668,32 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::ZeroPa
         let addr = add_index_to_zeropage_address(self.address_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, addr, 0);
+
+        // calculate overflow
+        let (value, overflow) = lhs.twos_complement_add(rhs, cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::ADC, address_mode::ZeroPageIndexedWithX, 0x75, 4);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ADC, address_mode::ZeroPageIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let addr = self.address_mode.unwrap();
+        let indexed_addr = add_index_to_zeropage_address(addr, cpu.x.read());
+        let lhs = Operand::new(cpu.acc.read());
+        let rhs = dereference_address_to_operand(cpu, indexed_addr, 0);
 
         // calculate overflow
         let (value, overflow) = lhs.twos_complement_add(rhs, cpu.ps.carry);

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -94,6 +94,35 @@ fn should_generate_absolute_indexed_with_y_address_mode_adc_machine_code() {
 }
 
 #[test]
+fn should_generate_indirect_y_indexed_address_mode_adc_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xff).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::ADC, address_mode::IndirectYIndexed(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_adc_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
@@ -104,6 +133,35 @@ fn should_generate_immediate_address_mode_adc_machine_code() {
         MOps::new(
             2,
             2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_x_indexed_indirect_address_mode_adc_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xff).unwrap(); // indirect addr
+
+    let op: Operation =
+        Instruction::new(mnemonic::ADC, address_mode::XIndexedIndirect(0x00)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -141,6 +141,33 @@ fn should_generate_zeropage_address_mode_adc_machine_code() {
     );
 }
 
+#[test]
+fn should_generate_zeropage_indexed_with_x_address_mode_adc_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0xff, 0xff).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ADC, address_mode::ZeroPageIndexedWithX(0xfa)).into();
+
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
 // AND
 
 #[test]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -15,6 +15,31 @@ use crate::cpu::{
 // ADC
 
 #[test]
+fn should_generate_absolute_address_mode_adc_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ADC, address_mode::Absolute(0x00ff)).into();
+
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_adc_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -40,6 +40,60 @@ fn should_generate_absolute_address_mode_adc_machine_code() {
 }
 
 #[test]
+fn should_generate_absolute_indexed_with_x_address_mode_adc_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ADC, address_mode::AbsoluteIndexedWithX(0x00fa)).into();
+
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_y_address_mode_adc_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ADC, address_mode::AbsoluteIndexedWithY(0x00fa)).into();
+
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_immediate_address_mode_adc_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -62,6 +62,31 @@ fn should_generate_immediate_address_mode_adc_machine_code() {
     );
 }
 
+#[test]
+fn should_generate_zeropage_address_mode_adc_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ADC, address_mode::ZeroPage(0xff)).into();
+
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x7f)
+            ]
+        ),
+        mc
+    );
+}
+
 // AND
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -151,6 +151,52 @@ fn should_cycle_on_adc_absolute_indexed_with_y_operation_without_overflow() {
 }
 
 #[test]
+fn should_cycle_on_adc_indirect_y_indexed_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x71, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xff).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_indirect_y_indexed_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x71, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00, 0xfa).unwrap();
+    cpu.address_map.write(0x01, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x50).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_adc_immediate_operation_with_overflow() {
     let cpu = generate_test_cpu_with_instructions(vec![0x69, 0xff])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));
@@ -166,6 +212,52 @@ fn should_cycle_on_adc_immediate_operation_with_overflow() {
             state.ps.zero
         ),
         (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_x_indexed_indirect_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x61, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0xff).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_x_indexed_indirect_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x61, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+    cpu.address_map.write(0x06, 0x00).unwrap();
+    cpu.address_map.write(0xff, 0x50).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
     );
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -67,6 +67,90 @@ fn should_cycle_on_adc_absolute_operation_without_overflow() {
 }
 
 #[test]
+fn should_cycle_on_adc_absolute_indexed_with_x_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x7d, 0xfa, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_absolute_indexed_with_x_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x7d, 0xfa, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0x50).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_absolute_indexed_with_y_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x79, 0xfa, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_absolute_indexed_with_y_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x79, 0xfa, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0x50).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_adc_immediate_operation_with_overflow() {
     let cpu = generate_test_cpu_with_instructions(vec![0x69, 0xff])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));
@@ -140,7 +224,7 @@ fn should_cycle_on_adc_zeropage_operation_without_overflow() {
             state.ps.overflow,
             state.ps.zero
         ),
-        (true, false, true, false)
+        (false, false, false, false)
     );
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -27,6 +27,46 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 }
 
 #[test]
+fn should_cycle_on_adc_absolute_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x6d, 0xff, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_absolute_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x6d, 0xff, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10));
+    cpu.address_map.write(0x00ff, 0x50).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_adc_immediate_operation_with_overflow() {
     let cpu = generate_test_cpu_with_instructions(vec![0x69, 0xff])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -105,6 +105,46 @@ fn should_cycle_on_adc_immediate_operation_without_overflow() {
 }
 
 #[test]
+fn should_cycle_on_adc_zeropage_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x65, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_zeropage_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x65, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10));
+    cpu.address_map.write(0x00ff, 0x50).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_and_absolute_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x2d, 0xff, 0x00])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -229,6 +229,48 @@ fn should_cycle_on_adc_zeropage_operation_without_overflow() {
 }
 
 #[test]
+fn should_cycle_on_adc_zeropage_indexed_with_x_operation_with_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x75, 0xfa])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x80))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x7f, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (true, false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_adc_zeropage_indexed_with_x_operation_without_overflow() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x75, 0xfa])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x10))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0x50).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x60, state.acc.read());
+    assert_eq!(
+        (
+            state.ps.carry,
+            state.ps.negative,
+            state.ps.overflow,
+            state.ps.zero
+        ),
+        (false, false, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_and_absolute_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x2d, 0xff, 0x00])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));


### PR DESCRIPTION
# Introduction
This PR implements the remaining addressing modes not yet implemented for the ADC instruction on the mos6502. This includes:

- absolute
- absolute indexed with x
- absolute indexed with y
- indirect y-indexed
- x-indexed indirect
- zeropage
- zeropage indexed with x

# Linked Issues
#42 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
