### PR TITLE
Implement JSR absolute instruction

### DIFF
--- a/src/cpu/mos6502/operations/addressing_mode.rs
+++ b/src/cpu/mos6502/operations/addressing_mode.rs
@@ -184,7 +184,7 @@ impl<'a> Parser<'a, &'a [u8], Relative> for Relative {
 }
 
 impl Relative {
-    /// Unpacks the enclosed address from a Relative addressmode into a
+    /// Unpacks the enclosed address from a Relative addressing mode into a
     /// corresponding i8 address.
     pub fn unwrap(self) -> i8 {
         self.into()
@@ -211,6 +211,20 @@ impl<'a> Parser<'a, &'a [u8], Indirect> for Indirect {
         parcel::take_n(any_byte(), 2)
             .map(|b| Indirect(u16::from_le_bytes([b[0], b[1]])))
             .parse(input)
+    }
+}
+
+impl Indirect {
+    /// Unpacks the enclosed address from a Indirect addressing mode into a
+    /// corresponding u16 address.
+    pub fn unwrap(self) -> u16 {
+        self.into()
+    }
+}
+
+impl From<Indirect> for u16 {
+    fn from(src: Indirect) -> Self {
+        src.0
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -285,8 +285,11 @@ pub struct JMP;
 
 generate_mnemonic_parser_and_offset!(JMP, 0x4c, 0x6c);
 
+/// Jump to a new location saving the return address.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct JSR;
+
+generate_mnemonic_parser_and_offset!(JSR, 0x20);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTS;

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1487,6 +1487,23 @@ fn should_cycle_on_jmp_indirect_operation() {
 }
 
 #[test]
+fn should_cycle_on_jsr_absolute_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x20, 0x50, 0x60]);
+
+    let sph = 0x1ffu16;
+    let spl = 0x1feu16;
+    let stack_base = 0x0100u16;
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6050, state.pc.read());
+    assert_eq!(0x01fd, stack_base.wrapping_add(state.sp.read() as u16));
+    assert_eq!(
+        (0x02, 0x60),
+        (state.address_map.read(spl), state.address_map.read(sph))
+    )
+}
+
+#[test]
 fn should_cycle_on_lda_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);
 


### PR DESCRIPTION
# Introduction
This PR Implements the JSR Absolute addressing mode instruction for the mos6502. In addition it implements an unwrap method for Relative addressing mode.
# Linked Issues
#51 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
