### PR TITLE
Implement RTS Implied Instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -291,8 +291,11 @@ pub struct JSR;
 
 generate_mnemonic_parser_and_offset!(JSR, 0x20);
 
+/// Return from subroutine.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTS;
+
+generate_mnemonic_parser_and_offset!(RTS, 0x60);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTI;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -2588,6 +2588,30 @@ fn should_generate_implied_addressing_mode_plp_machine_code() {
     )
 }
 
+// RTS
+
+#[test]
+fn should_generate_implied_addressing_mode_rts_machine_code() {
+    let mut cpu = MOS6502::default().with_sp_register(StackPointer::with_value(0xfd));
+    cpu.address_map.write(0x01fe, 0x02).unwrap();
+    cpu.address_map.write(0x01ff, 0x60).unwrap();
+
+    let op: Operation = Instruction::new(mnemonic::RTS, addressing_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            6,
+            vec![
+                gen_inc_8bit_register_microcode!(ByteRegisters::SP, 2),
+                gen_write_16bit_register_microcode!(WordRegisters::PC, 0x6002)
+            ]
+        ),
+        mc
+    );
+}
+
 // SBC
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1893,6 +1893,18 @@ fn should_cycle_on_plp_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_rts_implied_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x60])
+        .with_sp_register(register::StackPointer::with_value(0xfd));
+    cpu.address_map.write(0x01ff, 0x60).unwrap();
+    cpu.address_map.write(0x01fe, 0x02).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0xff, state.sp.read());
+    assert_eq!(0x6003, state.pc.read());
+}
+
+#[test]
 fn should_cycle_on_sbc_absolute_operation_with_overflow() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xed, 0xff, 0x00])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x50))


### PR DESCRIPTION
# Introduction
This PR implements the RTS Implied addressing mode instruction for the mos6502 processor.
# Linked Issues
#63 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
