### PR TITLE
Move Page type to address_map module

### DIFF
--- a/src/address_map/mod.rs
+++ b/src/address_map/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::{cmp::Eq, fmt::Debug, hash::Hash, ops::RangeInclusive};
 
 pub mod memory;
+pub mod page;
 
 #[cfg(test)]
 mod tests;

--- a/src/address_map/page.rs
+++ b/src/address_map/page.rs
@@ -1,0 +1,36 @@
+/// Page represents an 8-bit memory page for the purpose of determining if an
+/// address falls within the space of a page.
+pub struct Page<T>
+where
+    T: Ord,
+{
+    inner: std::ops::RangeInclusive<T>,
+}
+
+impl<T> Page<T>
+where
+    T: Ord,
+{
+    /// new takes a start and end value, generating an inclusive range representing the page.
+    #[allow(unused)]
+    pub fn new(start: T, end: T) -> Self {
+        Self { inner: start..=end }
+    }
+
+    /// Returns true if the passed address falls within the range of the page.
+    pub fn contains(&self, addr: T) -> bool {
+        self.inner.contains(&addr)
+    }
+}
+
+impl From<u16> for Page<u16> {
+    fn from(addr: u16) -> Self {
+        let page_size = 0xff;
+        let upper_page_bound: u16 = addr + (page_size - (addr % (page_size + 1)));
+        let lower_page_bound: u16 = upper_page_bound - page_size;
+
+        Self {
+            inner: lower_page_bound..=upper_page_bound,
+        }
+    }
+}

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use crate::address_map::Addressable;
+use crate::address_map::{page::Page, Addressable};
 use crate::cpu::{
     mos6502::{microcode::Microcode, register::*, Generate, MOS6502},
     register::Register,
@@ -14,36 +14,6 @@ pub mod mnemonic;
 
 #[cfg(test)]
 mod tests;
-
-/// Page represents an 8-bit memory page for the purpose of determining if an
-/// address falls within the space of a page.
-struct Page {
-    inner: std::ops::RangeInclusive<u16>,
-}
-
-impl Page {
-    #[allow(unused)]
-    fn new(start: u16, end: u16) -> Self {
-        Self { inner: start..=end }
-    }
-
-    /// Returns true if the passed address falls within the range of the page.
-    fn contains(&self, addr: u16) -> bool {
-        self.inner.contains(&addr)
-    }
-}
-
-impl From<u16> for Page {
-    fn from(addr: u16) -> Self {
-        let page_size = 0xff;
-        let upper_page_bound: u16 = addr + (page_size - (addr % (page_size + 1)));
-        let lower_page_bound: u16 = upper_page_bound - page_size;
-
-        Self {
-            inner: lower_page_bound..=upper_page_bound,
-        }
-    }
-}
 
 /// Takes two numerical values returning whether the bit is set for a specific
 /// place.


### PR DESCRIPTION
# Introduction
This PR generalizes the Page type to accept any Ord (generally a numeric) value and moves it under the address_map module with the other addressing types.

# Linked Issues
resolves #188 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
