### PR TITLE
Implement LSR Accumulator instruction

### DIFF
--- a/src/cpu/mos6502/operations/addressing_mode.rs
+++ b/src/cpu/mos6502/operations/addressing_mode.rs
@@ -2,8 +2,20 @@ extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
 use parcel::{parsers::byte::any_byte, MatchStatus, ParseResult, Parser};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Accumulator;
+
+impl Offset for Accumulator {
+    fn offset(&self) -> usize {
+        0
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], Accumulator> for Accumulator {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Accumulator> {
+        Ok(MatchStatus::Match((input, Accumulator)))
+    }
+}
 
 /// Implied address addressing mode. This is signified by no addressing mode
 /// arguments. An example instruction with an implied addressing mode would be.

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -122,8 +122,11 @@ generate_mnemonic_parser_and_offset!(DEY, 0x88);
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ASL;
 
+/// Shift one bit right (Memory or Accumulator).
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LSR;
+
+generate_mnemonic_parser_and_offset!(LSR, 0x4a);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROL;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -167,6 +167,18 @@ impl std::ops::BitXor for Operand<u8> {
     }
 }
 
+impl std::ops::Shr for Operand<u8> {
+    type Output = Self;
+
+    fn shr(self, other: Self) -> Self::Output {
+        let (lhs, rhs) = (self.unwrap(), other.unwrap());
+        let carry = bit_is_set!(lhs, 0); // if the lsb is set shift to carry
+        let value = Operand::new(lhs >> rhs);
+
+        Operand::with_flags(value.unwrap(), carry, value.negative, value.zero)
+    }
+}
+
 // addressing mode Unpackers
 
 /// Provides a wrapper around the operation of unpacking an addressing mode and
@@ -487,6 +499,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
                 mnemonic::LDY,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
+            inst_to_operation!(mnemonic::LSR, addressing_mode::Accumulator),
             inst_to_operation!(mnemonic::NOP, addressing_mode::Implied),
             inst_to_operation!(mnemonic::ORA, addressing_mode::Absolute::default()),
             inst_to_operation!(
@@ -3060,6 +3073,27 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDY, addressing_mode::Zer
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+            ],
+        )
+    }
+}
+
+// LSR
+
+gen_instruction_cycles_and_parser!(mnemonic::LSR, addressing_mode::Accumulator, 0x4a, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::LSR, addressing_mode::Accumulator> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.acc.read()) >> Operand::new(1u8);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1569,6 +1569,27 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::EOR, addressing_mode::Zer
     }
 }
 
+// LSR
+
+gen_instruction_cycles_and_parser!(mnemonic::LSR, addressing_mode::Accumulator, 0x4a, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::LSR, addressing_mode::Accumulator> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.acc.read()) >> Operand::new(1u8);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
 // ORA
 
 gen_instruction_cycles_and_parser!(mnemonic::ORA, addressing_mode::Absolute, 0x0d, 4);
@@ -3073,27 +3094,6 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDY, addressing_mode::Zer
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
-            ],
-        )
-    }
-}
-
-// LSR
-
-gen_instruction_cycles_and_parser!(mnemonic::LSR, addressing_mode::Accumulator, 0x4a, 2);
-
-impl Generate<MOS6502, MOps> for Instruction<mnemonic::LSR, addressing_mode::Accumulator> {
-    fn generate(self, cpu: &MOS6502) -> MOps {
-        let value = Operand::new(cpu.acc.read()) >> Operand::new(1u8);
-
-        MOps::new(
-            self.offset(),
-            self.cycles(),
-            vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1733,6 +1733,20 @@ fn should_cycle_on_ldy_zeropage_indexed_with_x_operation() {
 }
 
 #[test]
+fn should_cycle_on_lsr_accumulator_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x4a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x55));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x2a, state.acc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
     let state = cpu.run(3).unwrap();


### PR DESCRIPTION
# Introduction
This PR implements the LSR Accumulator addressing mode instruction for the mos6502.
# Linked Issues
#60 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
