### PR TITLE
Switch StepState to an enum

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -181,6 +181,9 @@ impl CPU<MOS6502> for StepState<MOS6502> {
     fn run(self, cycles: usize) -> StepState<MOS6502> {
         match self {
             StepState::Ready(cpu) => cpu.run(cycles),
+            StepState::NotReady(remaining, cpu) if cycles < remaining => {
+                StepState::NotReady(0, cpu)
+            }
             StepState::NotReady(remaining, cpu) => cpu.run(cycles - remaining),
         }
     }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -179,8 +179,10 @@ impl CPU<MOS6502> for MOS6502 {
 
 impl CPU<MOS6502> for StepState<MOS6502> {
     fn run(self, cycles: usize) -> StepState<MOS6502> {
-        let remaining = self.remaining;
-        self.cpu.run(cycles - remaining)
+        match self {
+            StepState::Ready(cpu) => cpu.run(cycles),
+            StepState::NotReady(remaining, cpu) => cpu.run(cycles - remaining),
+        }
     }
 }
 


### PR DESCRIPTION
# Introduction
This PR includes a small refactor to move StepState from a structure to an enum that represents it's two run states, Ready/NotReady. Functionally this remains the same implementation wise but provides a bit more clarity on the CPU implementations of the `run` method as to how a ready/notready state behaves. Example being

```rust
impl CPU<MOS6502> for StepState<MOS6502> {
    fn run(self, cycles: usize) -> StepState<MOS6502> {
        match self {
            StepState::Ready(cpu) => cpu.run(cycles),
            StepState::NotReady(remaining, cpu) if cycles < remaining => {
                StepState::NotReady(0, cpu)
            }
            StepState::NotReady(remaining, cpu) => cpu.run(cycles - remaining),
        }
    }
}
```

Which better illustrates how the stepstate strips excess cycles from the run.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
