### PR TITLE
Implement ROR Instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -131,8 +131,11 @@ generate_mnemonic_parser_and_offset!(LSR, 0x4e, 0x5e, 0x4a, 0x46, 0x56);
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROL;
 
+/// Rotate one bit right (Memory or Accumulator)
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROR;
+
+generate_mnemonic_parser_and_offset!(ROR, 0x6e, 0x7e, 0x6a, 0x66, 0x76);
 
 /// And Memory with Accumulator.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -41,6 +41,15 @@ trait SubTwosComplement<Rhs = Self> {
     fn twos_complement_sub(self, rhs: Rhs, carry: bool) -> (Self::Output, bool);
 }
 
+/// This Trait provides a rotate-right operation using the carry bit as shift
+/// in and the 0 bit as the shift out.
+trait Ror<Rhs = Self> {
+    type Output;
+
+    /// subtracts the left and right hand sides returning a cary using twos complement
+    fn ror(self, rhs: Rhs, carry: bool) -> Self::Output;
+}
+
 /// Represents a response that will yield a result that might or might not
 /// result in wrapping, overflow or negative values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -164,6 +173,19 @@ impl std::ops::BitXor for Operand<u8> {
         let (lhs, rhs) = (self.unwrap(), other.unwrap());
         let value = lhs ^ rhs;
         Self::new(value)
+    }
+}
+
+impl Ror for Operand<u8> {
+    type Output = Self;
+
+    fn ror(self, other: Self, carry: bool) -> Self::Output {
+        let (lhs, rhs) = (self.unwrap(), other.unwrap());
+        let carry_in = (carry as u8) << 7;
+        let carry_out = bit_is_set!(lhs, 0);
+        let shifted = Operand::new(lhs >> rhs | carry_in);
+
+        Operand::with_flags(shifted.unwrap(), carry_out, shifted.negative, shifted.zero)
     }
 }
 
@@ -532,6 +554,17 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::PHP, addressing_mode::Implied),
             inst_to_operation!(mnemonic::PLA, addressing_mode::Implied),
             inst_to_operation!(mnemonic::PLP, addressing_mode::Implied),
+            inst_to_operation!(mnemonic::ROR, addressing_mode::Absolute::default()),
+            inst_to_operation!(
+                mnemonic::ROR,
+                addressing_mode::AbsoluteIndexedWithX::default()
+            ),
+            inst_to_operation!(mnemonic::ROR, addressing_mode::Accumulator),
+            inst_to_operation!(mnemonic::ROR, addressing_mode::ZeroPage::default()),
+            inst_to_operation!(
+                mnemonic::ROR,
+                addressing_mode::ZeroPageIndexedWithX::default()
+            ),
             inst_to_operation!(mnemonic::RTS, addressing_mode::Implied),
             inst_to_operation!(mnemonic::SBC, addressing_mode::Absolute::default()),
             inst_to_operation!(
@@ -1899,6 +1932,124 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::ORA, addressing_mode::Zer
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+// ROR
+
+gen_instruction_cycles_and_parser!(mnemonic::ROR, addressing_mode::Absolute, 0x6e, 6);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ROR, addressing_mode::Absolute> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let addr = self.addressing_mode.unwrap();
+        let value =
+            dereference_address_to_operand(cpu, addr, 0).ror(Operand::new(1u8), cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(addr, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(
+    mnemonic::ROR,
+    addressing_mode::AbsoluteIndexedWithX,
+    0x7e,
+    7
+);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ROR, addressing_mode::AbsoluteIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let addr = self.addressing_mode.unwrap();
+        let indexed_addr = add_index_to_address(addr, index);
+        let value =
+            dereference_address_to_operand(cpu, addr, index).ror(Operand::new(1u8), cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::ROR, addressing_mode::Accumulator, 0x6a, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ROR, addressing_mode::Accumulator> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.acc.read()).ror(Operand::new(1u8), cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(mnemonic::ROR, addressing_mode::ZeroPage, 0x66, 5);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ROR, addressing_mode::ZeroPage> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let addr = self.addressing_mode.unwrap() as u16;
+        let value =
+            dereference_address_to_operand(cpu, addr, 0).ror(Operand::new(1u8), cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(addr, value.unwrap()),
+            ],
+        )
+    }
+}
+
+gen_instruction_cycles_and_parser!(
+    mnemonic::ROR,
+    addressing_mode::ZeroPageIndexedWithX,
+    0x76,
+    6
+);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::ROR, addressing_mode::ZeroPageIndexedWithX> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let index = cpu.x.read();
+        let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
+        let value = dereference_address_to_operand(cpu, indexed_addr, 0)
+            .ror(Operand::new(1u8), cpu.ps.carry);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -2602,18 +2602,17 @@ fn should_generate_implied_addressing_mode_pha_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        vec![
-            vec![],
-            vec![],
+        MOps::new(
+            1,
+            3,
             vec![
                 // should write to the top of the stack
                 gen_write_memory_microcode!(0x01ff, 0xff),
                 gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)
             ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
-    )
+        ),
+        mc
+    );
 }
 
 // PHP
@@ -2628,17 +2627,16 @@ fn should_generate_implied_addressing_mode_php_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        vec![
-            vec![],
-            vec![],
+        MOps::new(
+            1,
+            3,
             vec![
                 // should write to the top of the stack
                 gen_write_memory_microcode!(0x01ff, 0x55),
                 gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
-                gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)
             ]
-        ],
-        Into::<Vec<Vec<Microcode>>>::into(mc)
+        ),
+        mc
     )
 }
 
@@ -2700,6 +2698,145 @@ fn should_generate_implied_addressing_mode_plp_machine_code() {
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
+}
+
+// ROR
+
+#[test]
+fn should_generate_absolute_addressing_mode_ror_machine_code() {
+    let mut cpu = MOS6502::default().with_ps_register({
+        let mut ps = ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::Absolute(0x00ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0xd5)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_x_addressing_mode_ror_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ROR, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            7,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0xd5)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_accumulator_addressing_mode_ror_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xaa))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::Accumulator).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xd5)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_addressing_mode_ror_machine_code() {
+    let mut cpu = MOS6502::default().with_ps_register({
+        let mut ps = ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0xd5)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_indexed_with_x_addressing_mode_ror_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ROR, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0xd5)
+            ]
+        ),
+        mc
+    );
 }
 
 // RTS

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1965,6 +1965,101 @@ fn should_cycle_on_plp_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_ror_absolute_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x6e, 0xff, 0x00]).with_ps_register({
+        let mut ps = register::ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xd5, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_ror_absolute_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x7e, 0xfa, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(7).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xd5, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_ror_accumulator_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x6a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xaa))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xd5, state.acc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_ror_zeropage_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x66, 0xff]).with_ps_register({
+        let mut ps = register::ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xd5, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, true, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_ror_zeropage_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x76, 0xfa])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xd5, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (false, true, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_rts_implied_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x60])
         .with_sp_register(register::StackPointer::with_value(0xfd));


### PR DESCRIPTION
# Introduction
This PR Implements the ROR instruction for all addressing modes for the mos6502 processor.
# Linked Issues
#65 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
