### PR TITLE
Implement ROL instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -128,8 +128,11 @@ pub struct LSR;
 
 generate_mnemonic_parser_and_offset!(LSR, 0x4e, 0x5e, 0x4a, 0x46, 0x56);
 
+/// Rotate one bit left (Memory or Accumulator).
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROL;
+
+generate_mnemonic_parser_and_offset!(ROL, 0x2e, 0x3e, 0x2a, 0x26, 0x36);
 
 /// Rotate one bit right (Memory or Accumulator)
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -2700,6 +2700,145 @@ fn should_generate_implied_addressing_mode_plp_machine_code() {
     )
 }
 
+// ROL
+
+#[test]
+fn should_generate_absolute_addressing_mode_rol_machine_code() {
+    let mut cpu = MOS6502::default().with_ps_register({
+        let mut ps = ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::Absolute(0x00ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_x_addressing_mode_rol_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ROL, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            7,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_accumulator_addressing_mode_rol_machine_code() {
+    let cpu = MOS6502::default()
+        .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xaa))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::Accumulator).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_addressing_mode_rol_machine_code() {
+    let mut cpu = MOS6502::default().with_ps_register({
+        let mut ps = ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_indexed_with_x_addressing_mode_rol_machine_code() {
+    let mut cpu = MOS6502::default()
+        .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ROL, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x55)
+            ]
+        ),
+        mc
+    );
+}
+
 // ROR
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1965,6 +1965,101 @@ fn should_cycle_on_plp_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_rol_absolute_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x2e, 0xff, 0x00]).with_ps_register({
+        let mut ps = register::ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x55, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_rol_absolute_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x3e, 0xfa, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(7).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x55, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_rol_accumulator_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x2a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xaa))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x55, state.acc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_rol_zeropage_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x26, 0xff]).with_ps_register({
+        let mut ps = register::ProcessorStatus::default();
+        ps.carry = true;
+        ps
+    });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_rol_zeropage_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x36, 0xfa])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05))
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.carry = true;
+            ps
+        });
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x55, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
 fn should_cycle_on_ror_absolute_operation() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x6e, 0xff, 0x00]).with_ps_register({
         let mut ps = register::ProcessorStatus::default();


### PR DESCRIPTION
# Introduction
This PR Implements the ROL instruction for all addresing modes of the mos6502 instruction set.
# Linked Issues
#54 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
