### PR TITLE
Implement ASL instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -119,8 +119,12 @@ pub struct DEY;
 generate_mnemonic_parser_and_offset!(DEY, 0x88);
 
 // Shift and Rotate
+
+/// Shift one bit left (Memory or Accumulator)
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ASL;
+
+generate_mnemonic_parser_and_offset!(ASL, 0x0e, 0x1e, 0x0a, 0x06, 0x16);
 
 /// Shift one bit right (Memory or Accumulator).
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -419,6 +419,122 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
     );
 }
 
+// ASL
+
+#[test]
+fn should_generate_absolute_addressing_mode_asl_machine_code() {
+    let mut cpu = MOS6502::default();
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::Absolute(0x00ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x54)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ASL, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            7,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x54)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_accumulator_addressing_mode_asl_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xaa));
+    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::Accumulator).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x54)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_addressing_mode_asl_machine_code() {
+    let mut cpu = MOS6502::default();
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            5,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x54)
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_indexed_with_x_addressing_mode_asl_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+    let op: Operation =
+        Instruction::new(mnemonic::ASL, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            6,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_memory_microcode!(0x00ff, 0x54)
+            ]
+        ),
+        mc
+    );
+}
+
 // BCC
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -467,6 +467,78 @@ fn should_cycle_on_and_zeropage_indexed_with_x_operation() {
 }
 
 #[test]
+fn should_cycle_on_asl_absolute_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x0e, 0xff, 0x00]);
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x54, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_asl_absolute_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x1e, 0xfa, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(7).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0x54, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_asl_accumulator_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x0a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xaa));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x54, state.acc.read());
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_asl_zeropage_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x06, 0xff]);
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(5).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x54, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
+fn should_cycle_on_asl_zeropage_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x16, 0xfa])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x00ff, 0xaa).unwrap();
+
+    let state = cpu.run(6).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x54, state.address_map.read(0x00ff));
+    assert_eq!(
+        (state.ps.carry, state.ps.negative, state.ps.zero),
+        (true, false, false)
+    );
+}
+
+#[test]
 fn bcc_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x90, 0x08]);
     cpu.ps.carry = false;


### PR DESCRIPTION
# Introduction
This PR implements the ASL instruction for all addressing modes for the mos6502 processor.
# Linked Issues
#47 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
