### PR TITLE
Feature/45/implement brk implied instruction

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,25 +9,25 @@ fn main() {
     // A ReadOnly memory segment containing a small rom consisting of a
     // LDA/STA loop. This will run until stopped. This exists in the address
     // space inclusively beteen 0x7fea and 0x7fff.
-    let rom = Memory::<ReadOnly>::new(0x7fea, 0x7fff).load(vec![
-        0xa9, 0x01, 0x8d, 0x00, 0x80, 0xa9, 0x02, 0x8d, 0x01, 0x80, 0xa9, 0x03, 0x8d, 0x02, 0x80,
-        0x4c, 0xea, 0x7f, 0xea, 0x7f, 0x00, 0x00,
+    let rom = Memory::<ReadOnly>::new(0xffea, 0xffff).load(vec![
+        0xa9, 0x01, 0x8d, 0x00, 0x02, 0xa9, 0x02, 0x8d, 0x01, 0x02, 0xa9, 0x03, 0x8d, 0x02, 0x02,
+        0x4c, 0xea, 0xff, 0xea, 0xff, 0x00, 0x00,
     ]);
 
     // A segment of ReadWrite memory existing inclusively in the the space
     // between 0x8000 and 0xffff.
-    let ram = Memory::<ReadWrite>::new(0x8000, 0xffff);
+    let ram = Memory::<ReadWrite>::new(0x0200, 0x7fff);
     let cpu = MOS6502::default()
         // Registers the address space and the rom as addressable memory with
         // the cpu. This accepts any implementation of the Addressable trait.
-        .register_address_space(0x7fea..=0x7fff, rom)
+        .register_address_space(0xffea..=0xffff, rom)
         // Registration can fail, this unwraps the result.
         .unwrap()
-        .register_address_space(0x8000..=0xffff, ram)
+        .register_address_space(0x0200..=0x7fff, ram)
         .unwrap()
         // Resets the cpu and loads the reset vector into the PC.
         .reset()
-        // This return a StepState<MOS6502> which is unwrapped to return the 
+        // This return a StepState<MOS6502> which is unwrapped to return the
         // enclosing cpu.
         .unwrap();
 

--- a/examples/custom_peripheral.rs
+++ b/examples/custom_peripheral.rs
@@ -61,16 +61,16 @@ impl Addressable<u16> for VIA {
 fn main() {
     // A small rom that loops over write 01010101 and 10101010 to port a where
     // it is output. this will loop endlessly until stopped.
-    let rom = Memory::<ReadOnly>::new(0x7fea, 0x7fff).load(vec![
+    let rom = Memory::<ReadOnly>::new(0xffea, 0xffff).load(vec![
         0xa9, 0xff, 0x8d, 0x02, 0x80, 0xa9, 0x55, 0x8d, 0x00, 0x80, 0xa9, 0xaa, 0x8d, 0x00, 0x80,
-        0x4c, 0xef, 0x7f, 0xea, 0x7f, 0x00, 0x00,
+        0x4c, 0xef, 0xff, 0xea, 0xff, 0x00, 0x00,
     ]);
 
     let via = VIA::new(0x8000);
     let cpu = MOS6502::default()
         // Registers the address space and the rom as addressable memory with
         // the cpu. This accepts any implementation of the Addressable trait.
-        .register_address_space(0x7fea..=0x7fff, rom)
+        .register_address_space(0xffea..=0xffff, rom)
         // Registration can fail, this unwraps the result.
         .unwrap()
         .register_address_space(0x8000..=0x8003, via)

--- a/examples/microcode_step_capture.rs
+++ b/examples/microcode_step_capture.rs
@@ -9,21 +9,21 @@ fn main() {
     // A ReadOnly memory segment containing a small rom consisting of a
     // LDA/STA loop. This will run until stopped. This exists in the address
     // space inclusively beteen 0x7fea and 0x7fff.
-    let rom = Memory::<ReadOnly>::new(0x7fea, 0x7fff).load(vec![
-        0xa9, 0x01, 0x8d, 0x00, 0x80, 0xa9, 0x02, 0x8d, 0x01, 0x80, 0xa9, 0x03, 0x8d, 0x02, 0x80,
-        0x4c, 0xea, 0x7f, 0xea, 0x7f, 0x00, 0x00,
+    let rom = Memory::<ReadOnly>::new(0xffea, 0xffff).load(vec![
+        0xa9, 0x01, 0x8d, 0x00, 0x02, 0xa9, 0x02, 0x8d, 0x01, 0x02, 0xa9, 0x03, 0x8d, 0x02, 0x02,
+        0x4c, 0xea, 0xff, 0xea, 0xff, 0x00, 0x00,
     ]);
 
     // A segment of ReadWrite memory existing inclusively in the the space
     // between 0x8000 and 0xffff.
-    let ram = Memory::<ReadWrite>::new(0x8000, 0xffff);
+    let ram = Memory::<ReadWrite>::new(0x0200, 0x7fff);
     let cpu = MOS6502::default()
         // Registers the address space and the rom as addressable memory with
         // the cpu. This accepts any implementation of the Addressable trait.
-        .register_address_space(0x7fea..=0x7fff, rom)
+        .register_address_space(0xffea..=0xffff, rom)
         // Registration can fail, this unwraps the result.
         .unwrap()
-        .register_address_space(0x8000..=0xffff, ram)
+        .register_address_space(0x0200..=0x7fff, ram)
         .unwrap()
         // Resets the cpu and loads the reset vector into the PC.
         .reset()

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -16,8 +16,13 @@ pub mod microcode;
 #[cfg(test)]
 mod tests;
 
-const RESET_VECTOR_LL: u16 = 0xfffc;
-const RESET_VECTOR_HH: u16 = 0xfffd;
+// Address vectors
+pub const NMI_VECTOR_LL: u16 = 0xfffa;
+pub const NMI_VECTOR_HH: u16 = 0xfffb;
+pub const RESET_VECTOR_LL: u16 = 0xfffc;
+pub const RESET_VECTOR_HH: u16 = 0xfffd;
+pub const IRQ_VECTOR_LL: u16 = 0xfffe;
+pub const IRQ_VECTOR_HH: u16 = 0xffff;
 
 pub mod register;
 use register::{

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -16,6 +16,9 @@ pub mod microcode;
 #[cfg(test)]
 mod tests;
 
+const RESET_VECTOR_LL: u16 = 0xfffc;
+const RESET_VECTOR_HH: u16 = 0xfffd;
+
 pub mod register;
 use register::{
     ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter, ProgramStatusFlags,
@@ -98,8 +101,8 @@ impl MOS6502 {
     /// emulates the reset process of the CPU.
     pub fn reset(self) -> StepState<Self> {
         let mut cpu = MOS6502::with_addressmap(self.address_map);
-        let lsb: u8 = cpu.address_map.read(0xfffc);
-        let msb: u8 = cpu.address_map.read(0xfffd);
+        let lsb: u8 = cpu.address_map.read(RESET_VECTOR_LL);
+        let msb: u8 = cpu.address_map.read(RESET_VECTOR_HH);
 
         cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
         cpu.sp = StackPointer::default();

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -98,8 +98,8 @@ impl MOS6502 {
     /// emulates the reset process of the CPU.
     pub fn reset(self) -> StepState<Self> {
         let mut cpu = MOS6502::with_addressmap(self.address_map);
-        let lsb: u8 = cpu.address_map.read(0x7ffc);
-        let msb: u8 = cpu.address_map.read(0x7ffd);
+        let lsb: u8 = cpu.address_map.read(0xfffc);
+        let msb: u8 = cpu.address_map.read(0xfffd);
 
         cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
         cpu.sp = StackPointer::default();

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -350,8 +350,12 @@ pub struct CLV;
 generate_mnemonic_parser_and_offset!(CLV, 0xb8);
 
 // Misc
+
+/// Force Break
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BRK;
+
+generate_mnemonic_parser_and_offset!(BRK, 0x00);
 
 /// Represents a `nop` instruction, only implemented for the implied address
 /// mode and functions as a "No Instruction".

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -15,6 +15,9 @@ pub mod mnemonic;
 #[cfg(test)]
 mod tests;
 
+const IRQ_VECTOR_LL: u16 = 0xfffe;
+const IRQ_VECTOR_HH: u16 = 0xffff;
+
 /// Takes two numerical values returning whether the bit is set for a specific
 /// place.
 macro_rules! bit_is_set {
@@ -456,6 +459,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::BMI, addressing_mode::Relative::default()),
             inst_to_operation!(mnemonic::BNE, addressing_mode::Relative::default()),
             inst_to_operation!(mnemonic::BPL, addressing_mode::Relative::default()),
+            inst_to_operation!(mnemonic::BRK, addressing_mode::Implied::default()),
             inst_to_operation!(mnemonic::BVC, addressing_mode::Relative::default()),
             inst_to_operation!(mnemonic::BVS, addressing_mode::Relative::default()),
             inst_to_operation!(mnemonic::CLC, addressing_mode::Implied),
@@ -3643,16 +3647,6 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDY, addressing_mode::Zer
     }
 }
 
-// NOP
-
-gen_instruction_cycles_and_parser!(mnemonic::NOP, addressing_mode::Implied, 0xea, 2);
-
-impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, addressing_mode::Implied> {
-    fn generate(self, _: &MOS6502) -> MOps {
-        MOps::new(self.offset(), self.cycles(), vec![])
-    }
-}
-
 // PHA
 
 gen_instruction_cycles_and_parser!(mnemonic::PHA, addressing_mode::Implied, 0x48, 3);
@@ -4144,5 +4138,56 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::TYA, addressing_mode::Imp
                 gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
             ],
         )
+    }
+}
+
+// Misc
+
+// BRK
+
+gen_instruction_cycles_and_parser!(mnemonic::BRK, addressing_mode::Implied, 0x00, 7);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::BRK, addressing_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let ps = cpu.ps.read();
+
+        let sp_pcl: u16 = stack_pointer_from_byte_value(cpu.sp.read());
+        let sp_pch: u16 = stack_pointer_from_byte_value(cpu.sp.read().wrapping_sub(1));
+        let sp_ps: u16 = stack_pointer_from_byte_value(cpu.sp.read().wrapping_sub(2));
+
+        // Add 1 to the program counter and grab as little-endian bytes.
+        let [pcl, pch] = cpu.pc.read().wrapping_add(1).to_le_bytes();
+
+        // Grab IRQ/BRK vector
+        let irq_vector = u16::from_le_bytes([
+            cpu.address_map.read(IRQ_VECTOR_LL),
+            cpu.address_map.read(IRQ_VECTOR_HH),
+        ]);
+
+        MOps::new(
+            0, // manually modified in the instruction
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Break, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),
+                gen_write_memory_microcode!(sp_pcl, pcl),
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_write_memory_microcode!(sp_pch, pch),
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_write_memory_microcode!(sp_ps, ps), // PS Register
+                gen_dec_8bit_register_microcode!(ByteRegisters::SP, 1),
+                gen_write_16bit_register_microcode!(WordRegisters::PC, irq_vector),
+            ],
+        )
+    }
+}
+
+// NOP
+
+gen_instruction_cycles_and_parser!(mnemonic::NOP, addressing_mode::Implied, 0xea, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, addressing_mode::Implied> {
+    fn generate(self, _: &MOS6502) -> MOps {
+        MOps::new(self.offset(), self.cycles(), vec![])
     }
 }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use crate::address_map::{page::Page, Addressable};
 use crate::cpu::{
-    mos6502::{microcode::Microcode, register::*, Generate, MOS6502},
+    mos6502::{microcode::Microcode, register::*, Generate, IRQ_VECTOR_HH, IRQ_VECTOR_LL, MOS6502},
     register::Register,
     Cyclable, Offset,
 };
@@ -14,9 +14,6 @@ pub mod mnemonic;
 
 #[cfg(test)]
 mod tests;
-
-const IRQ_VECTOR_LL: u16 = 0xfffe;
-const IRQ_VECTOR_HH: u16 = 0xffff;
 
 /// Takes two numerical values returning whether the bit is set for a specific
 /// place.

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -713,6 +713,24 @@ fn bpl_relative_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn should_cycle_on_brk_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x00, 0x12])
+        .with_ps_register({
+            let mut ps = register::ProcessorStatus::default();
+            ps.brk = false;
+            ps
+        })
+        .register_address_space(
+            0xfffe..=0xffff,
+            Memory::<ReadOnly>::new(0xfffe, 0xffff).load(vec![0x78, 0x56]),
+        )
+        .unwrap();
+    let state = cpu.run(7).unwrap();
+    assert_eq!(0x5678, state.pc.read());
+    assert_eq!((true, true), (state.ps.brk, state.ps.interrupt_disable))
+}
+
+#[test]
 fn bvc_relative_operation_should_jump_when_overflow_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x50, 0x08]);
     cpu.ps.overflow = false;


### PR DESCRIPTION
# Introduction
This PR implements the BRK instruction for the mos6502 processor. In addition this includes fixes for the reset vector which previously was set at 7fffc/7ffd incorrectly.
# Linked Issues
#45 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
