### PR TITLE
Implement RTI implied instruction.

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -310,8 +310,11 @@ pub struct RTS;
 
 generate_mnemonic_parser_and_offset!(RTS, 0x60);
 
+/// Return from interrupt.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTI;
+
+generate_mnemonic_parser_and_offset!(RTI, 0x40);
 
 // Set and Clear
 #[derive(Debug, Default, Clone, Copy, PartialEq)]


### PR DESCRIPTION
# Introduction
This PR implements the RTI implied addressing mode instruction for the mos6502 processor.
# Linked Issues
#58 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
