### PR TITLE
Implement BIT instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -182,8 +182,11 @@ pub struct CPY;
 
 generate_mnemonic_parser_and_offset!(CPY, 0xcc, 0xc0, 0xc4);
 
+// Test Bits in Memory with Accumulator.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BIT;
+
+generate_mnemonic_parser_and_offset!(BIT, 0x24, 0x2c);
 
 // Branch
 #[derive(Debug, Default, Clone, Copy, PartialEq)]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -794,6 +794,52 @@ fn should_generate_bmi_machine_code_with_no_jump() {
     );
 }
 
+// BIT
+
+#[test]
+fn should_generate_absolute_addressing_mode_bit_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation = Instruction::new(mnemonic::BIT, addressing_mode::Absolute(0x00ff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_zeropage_addressing_mode_bit_machine_code() {
+    let mut cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+    let op: Operation = Instruction::new(mnemonic::BIT, addressing_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+            ]
+        ),
+        mc
+    );
+}
+
 // BNE
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -655,6 +655,36 @@ fn bmi_relative_operation_should_not_jump_when_zero_unset() {
 }
 
 #[test]
+fn should_cycle_on_bit_absolute_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x2c, 0xff, 0x00])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6003, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(
+        (false, true, false),
+        (state.ps.negative, state.ps.overflow, state.ps.zero)
+    );
+}
+
+#[test]
+fn should_cycle_on_bit_zeropage_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0x24, 0xff])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff));
+    cpu.address_map.write(0x00ff, 0x55).unwrap();
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(
+        (false, true, false),
+        (state.ps.negative, state.ps.overflow, state.ps.zero)
+    );
+}
+
+#[test]
 fn bne_relative_operation_should_jump_when_zero_set() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0xd0, 0x08]);
     cpu.ps.zero = false;


### PR DESCRIPTION
# Introduction
This PR includes implementations of the BIT instruction for all addressing modes for the mos6502 processor.
# Linked Issues
#53 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
