### PR TITLE
Remove extern crate references

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,3 @@
-extern crate mainspring;
 use mainspring::address_map::memory::{Memory, ReadOnly, ReadWrite};
 use mainspring::cpu::mos6502::MOS6502;
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,7 +7,7 @@ use mainspring::prelude::v1::*;
 fn main() {
     // A ReadOnly memory segment containing a small rom consisting of a
     // LDA/STA loop. This will run until stopped. This exists in the address
-    // space inclusively beteen 0xffea and 0xffff.
+    // space inclusively between 0xffea and 0xffff.
     let rom = Memory::<ReadOnly>::new(0xffea, 0xffff).load(vec![
         0xa9, 0x01, 0x8d, 0x00, 0x02, 0xa9, 0x02, 0x8d, 0x01, 0x02, 0xa9, 0x03, 0x8d, 0x02, 0x02,
         0x4c, 0xea, 0xff, 0xea, 0xff, 0x00, 0x00,
@@ -31,7 +31,7 @@ fn main() {
         .unwrap();
 
     // Run the cpu for 1,000,000 cycles, and returns a StepState<MOS6502> which
-    // we unwrap to return a CPU snapshotted at it's state.
+    // is unwrapped to return a CPU snapshot at its current state.
     let state = cpu.run(1_000_000).unwrap();
 
     println!("{:?}", state);

--- a/examples/custom_peripheral.rs
+++ b/examples/custom_peripheral.rs
@@ -1,6 +1,5 @@
 //! A small demonstration example of mainspring showing a basic custom Addressable implementation.
 
-extern crate mainspring;
 use mainspring::address_map::memory::{Memory, ReadOnly};
 use mainspring::cpu::mos6502::MOS6502;
 

--- a/examples/custom_peripheral.rs
+++ b/examples/custom_peripheral.rs
@@ -7,7 +7,7 @@ use mainspring::cpu::mos6502::MOS6502;
 use mainspring::prelude::v1::*;
 
 /// VIA functions as an analogy to the 6522 VIA chip. However, only a subset of
-/// functionality has be implemented for this demo. For the case of this example,
+/// functionality has been implemented for this demo. For the case of this example,
 /// all ports are configured in write mode with predefined addresses.
 #[derive(Clone)]
 pub struct VIA {
@@ -80,6 +80,6 @@ fn main() {
         // enclosing cpu.
         .unwrap();
 
-    // runs the program for 40 cycles
+    // Runs the program for 40 cycles.
     cpu.run(40).unwrap();
 }

--- a/examples/microcode_step_capture.rs
+++ b/examples/microcode_step_capture.rs
@@ -1,4 +1,3 @@
-extern crate mainspring;
 use mainspring::address_map::memory::{Memory, ReadOnly, ReadWrite};
 use mainspring::cpu::mos6502::{microcode::Microcode, Execute, MOS6502};
 

--- a/examples/microcode_step_capture.rs
+++ b/examples/microcode_step_capture.rs
@@ -7,7 +7,7 @@ use mainspring::prelude::v1::*;
 fn main() {
     // A ReadOnly memory segment containing a small rom consisting of a
     // LDA/STA loop. This will run until stopped. This exists in the address
-    // space inclusively beteen 0xffea and 0xffff.
+    // space inclusively between 0xffea and 0xffff.
     let rom = Memory::<ReadOnly>::new(0xffea, 0xffff).load(vec![
         0xa9, 0x01, 0x8d, 0x00, 0x02, 0xa9, 0x02, 0x8d, 0x01, 0x02, 0xa9, 0x03, 0x8d, 0x02, 0x02,
         0x4c, 0xea, 0xff, 0xea, 0xff, 0x00, 0x00,
@@ -49,7 +49,7 @@ fn main() {
 
     println!(
         "{:?}",
-        // Microcode can then be folded onto a cpu to replay it's state onto a fresh cpu.
+        // Microcode can then be folded onto a cpu to replay its state onto a fresh cpu.
         states.into_iter().fold(cpu.clone(), |c, mc| mc.execute(c))
     );
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use std::convert::TryFrom;
 use std::ops::RangeInclusive;
 

--- a/src/cpu/mos6502/operations/addressing_mode.rs
+++ b/src/cpu/mos6502/operations/addressing_mode.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
 use parcel::{parsers::byte::any_byte, MatchStatus, ParseResult, Parser};
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::cpu::Offset;
 
 macro_rules! generate_mnemonic_parser_and_offset {

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,4 +1,3 @@
-extern crate parcel;
 use crate::address_map::{page::Page, Addressable};
 use crate::cpu::{
     mos6502::{microcode::Microcode, register::*, Generate, IRQ_VECTOR_HH, IRQ_VECTOR_LL, MOS6502},


### PR DESCRIPTION
# Introduction
This PR removes all unnecessary `extern crate` references which are not required for the 2018 edition of rust. Additional this includes some documentation updates.

# Linked Issues
resolves #210 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
