### PR TITLE
Convert Operations type to isa-mos6502::InstructionVariant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.1" }
-isa-mos6502 = { git = "https://github.com/ncatelli/isa-mos6502", tag = "v0.1.0" }
+isa-mos6502 = { git = "https://github.com/ncatelli/isa-mos6502", tag = "v0.2.0" }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -112,13 +112,13 @@ impl MOS6502 {
         StepState::new(6, cpu)
     }
 
-    /// emulates the reset process of the CPU, exporting the options as a MOps type
-    pub fn reset_as_mops(&self) -> operations::MOps {
+    /// emulates the reset process of the CPU, exporting the options as a Operations type
+    pub fn reset_as_mops(&self) -> operations::Operations {
         let lsb: u8 = self.address_map.read(RESET_VECTOR_LL);
         let msb: u8 = self.address_map.read(RESET_VECTOR_HH);
         let pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
 
-        operations::MOps::new(
+        operations::Operations::new(
             0,
             6,
             vec![
@@ -219,7 +219,7 @@ impl CPU<MOS6502> for StepState<MOS6502> {
 }
 
 impl IntoIterator for MOS6502 {
-    type Item = operations::MOps;
+    type Item = operations::Operations;
     type IntoIter = MOS6502IntoIterator;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -244,9 +244,9 @@ impl MOS6502IntoIterator {
 }
 
 impl Iterator for MOS6502IntoIterator {
-    type Item = operations::MOps;
+    type Item = operations::Operations;
 
-    fn next(&mut self) -> Option<operations::MOps> {
+    fn next(&mut self) -> Option<operations::Operations> {
         let pc = self.state.pc.read();
         let opcodes: [u8; 3] = [
             self.state.address_map.read(pc),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -4,7 +4,7 @@ use crate::cpu::{
     register::Register,
     Cyclable, Offset,
 };
-use isa_mos6502::{addressing_mode, mnemonic, Instruction};
+use isa_mos6502::{addressing_mode, mnemonic, Instruction, InstructionVariant};
 use parcel::{ParseResult, Parser};
 use std::fmt::Debug;
 use std::num::Wrapping;
@@ -339,55 +339,524 @@ impl From<MOps> for Vec<Vec<Microcode>> {
     }
 }
 
-/// Operation functions as a concrete wrapper around all executable components
-/// of a 6502 operation.
-pub struct Operation {
-    offset: usize,
-    cycles: usize,
-    generator: Box<dyn Fn(&MOS6502) -> MOps>,
-}
-
-impl Operation {
-    pub fn new(offset: usize, cycles: usize, generator: Box<dyn Fn(&MOS6502) -> MOps>) -> Self {
-        Self {
-            offset,
-            cycles,
-            generator,
-        }
-    }
-}
-
-impl Cyclable for Operation {
-    fn cycles(&self) -> usize {
-        self.cycles
-    }
-}
-
-impl Offset for Operation {
-    fn offset(&self) -> usize {
-        self.offset
-    }
-}
-
-impl Generate<MOS6502, MOps> for Operation {
+/// Dispatch a generate method to each corresponding generic types generate method.
+impl Generate<MOS6502, MOps> for InstructionVariant {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        (self.generator)(cpu)
+        match self {
+            InstructionVariant::ADCAbsolute(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::ADCAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ADCAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ADCIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::ADCImmediate(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::ADCXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::ADCZeroPage(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::ADCZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::ADC, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ANDAbsolute(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::ANDAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ANDAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ANDIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::ANDImmediate(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::ANDXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::ANDZeroPage(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::ANDZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::AND, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ASLAbsolute(am) => {
+                Instruction::new(mnemonic::ASL, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::ASLAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::ASL, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ASLAccumulator => {
+                Instruction::new(mnemonic::ASL, addressing_mode::Accumulator).generate(cpu)
+            }
+            InstructionVariant::ASLZeroPage(am) => {
+                Instruction::new(mnemonic::ASL, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::ASLZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::ASL, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::BCCRelative(am) => {
+                Instruction::new(mnemonic::BCC, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BCSRelative(am) => {
+                Instruction::new(mnemonic::BCS, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BEQRelative(am) => {
+                Instruction::new(mnemonic::BEQ, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BMIRelative(am) => {
+                Instruction::new(mnemonic::BMI, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BITAbsolute(am) => {
+                Instruction::new(mnemonic::BIT, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::BITZeroPage(am) => {
+                Instruction::new(mnemonic::BIT, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::BNERelative(am) => {
+                Instruction::new(mnemonic::BNE, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BPLRelative(am) => {
+                Instruction::new(mnemonic::BPL, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BRKImplied => {
+                Instruction::new(mnemonic::BRK, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::BVCRelative(am) => {
+                Instruction::new(mnemonic::BVC, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::BVSRelative(am) => {
+                Instruction::new(mnemonic::BVS, addressing_mode::Relative(am)).generate(cpu)
+            }
+            InstructionVariant::CLCImplied => {
+                Instruction::new(mnemonic::CLC, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::CLDImplied => {
+                Instruction::new(mnemonic::CLD, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::CLIImplied => {
+                Instruction::new(mnemonic::CLI, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::CLVImplied => {
+                Instruction::new(mnemonic::CLV, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::CMPAbsolute(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::CMPAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::CMPAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::CMPIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::CMPImmediate(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::CMPXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::CMPZeroPage(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::CMPZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::CMP, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::CPXAbsolute(am) => {
+                Instruction::new(mnemonic::CPX, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::CPXImmediate(am) => {
+                Instruction::new(mnemonic::CPX, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::CPXZeroPage(am) => {
+                Instruction::new(mnemonic::CPX, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::CPYAbsolute(am) => {
+                Instruction::new(mnemonic::CPY, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::CPYImmediate(am) => {
+                Instruction::new(mnemonic::CPY, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::CPYZeroPage(am) => {
+                Instruction::new(mnemonic::CPY, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::DECAbsolute(am) => {
+                Instruction::new(mnemonic::DEC, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::DECAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::DEC, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::DECZeroPage(am) => {
+                Instruction::new(mnemonic::DEC, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::DECZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::DEC, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::DEXImplied => {
+                Instruction::new(mnemonic::DEX, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::DEYImplied => {
+                Instruction::new(mnemonic::DEY, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::EORAbsolute(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::EORAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::EORAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::EORIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::EORImmediate(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::EORXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::EORZeroPage(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::EORZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::EOR, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::INCAbsolute(am) => {
+                Instruction::new(mnemonic::INC, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::INCAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::INC, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::INCZeroPage(am) => {
+                Instruction::new(mnemonic::INC, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::INCZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::INC, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::INXImplied => {
+                Instruction::new(mnemonic::INX, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::INYImplied => {
+                Instruction::new(mnemonic::INY, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::JMPAbsolute(am) => {
+                Instruction::new(mnemonic::JMP, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::JMPIndirect(am) => {
+                Instruction::new(mnemonic::JMP, addressing_mode::Indirect(am)).generate(cpu)
+            }
+            InstructionVariant::JSRAbsolute(am) => {
+                Instruction::new(mnemonic::JSR, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::LDAAbsolute(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::LDAAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDAAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDAIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::LDAImmediate(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::LDAXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::LDAZeroPage(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::LDAZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::LDA, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDXAbsolute(am) => {
+                Instruction::new(mnemonic::LDX, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::LDXAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::LDX, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDXImmediate(am) => {
+                Instruction::new(mnemonic::LDX, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::LDXZeroPage(am) => {
+                Instruction::new(mnemonic::LDX, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::LDXZeroPageIndexedWithY(am) => {
+                Instruction::new(mnemonic::LDX, addressing_mode::ZeroPageIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDYAbsolute(am) => {
+                Instruction::new(mnemonic::LDY, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::LDYAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::LDY, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LDYImmediate(am) => {
+                Instruction::new(mnemonic::LDY, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::LDYZeroPage(am) => {
+                Instruction::new(mnemonic::LDY, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::LDYZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::LDY, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LSRAbsolute(am) => {
+                Instruction::new(mnemonic::LSR, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::LSRAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::LSR, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::LSRAccumulator => {
+                Instruction::new(mnemonic::LSR, addressing_mode::Accumulator).generate(cpu)
+            }
+            InstructionVariant::LSRZeroPage(am) => {
+                Instruction::new(mnemonic::LSR, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::LSRZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::LSR, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::NOPImplied => {
+                Instruction::new(mnemonic::NOP, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::ORAAbsolute(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::ORAAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ORAAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ORAIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::ORAImmediate(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::ORAXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::ORAZeroPage(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::ORAZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::ORA, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::PHAImplied => {
+                Instruction::new(mnemonic::PHA, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::PHPImplied => {
+                Instruction::new(mnemonic::PHP, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::PLAImplied => {
+                Instruction::new(mnemonic::PLA, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::PLPImplied => {
+                Instruction::new(mnemonic::PLP, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::ROLAbsolute(am) => {
+                Instruction::new(mnemonic::ROL, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::ROLAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::ROL, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::ROLAccumulator => {
+                Instruction::new(mnemonic::ROL, addressing_mode::Accumulator).generate(cpu)
+            }
+            InstructionVariant::ROLZeroPage(am) => {
+                Instruction::new(mnemonic::ROL, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::ROLZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::ROL, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::RORAbsolute(am) => {
+                Instruction::new(mnemonic::ROR, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::RORAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::ROR, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::RORAccumulator => {
+                Instruction::new(mnemonic::ROR, addressing_mode::Accumulator).generate(cpu)
+            }
+            InstructionVariant::RORZeroPage(am) => {
+                Instruction::new(mnemonic::ROR, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::RORZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::ROR, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::RTIImplied => {
+                Instruction::new(mnemonic::RTI, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::RTSImplied => {
+                Instruction::new(mnemonic::RTS, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::SBCAbsolute(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::SBCAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::SBCAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::SBCIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::SBCImmediate(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::Immediate(am)).generate(cpu)
+            }
+            InstructionVariant::SBCXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::SBCZeroPage(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::SBCZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::SBC, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::STAAbsolute(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::STAAbsoluteIndexedWithX(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::AbsoluteIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::STAAbsoluteIndexedWithY(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::AbsoluteIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::STAIndirectYIndexed(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::IndirectYIndexed(am)).generate(cpu)
+            }
+            InstructionVariant::STAXIndexedIndirect(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::XIndexedIndirect(am)).generate(cpu)
+            }
+            InstructionVariant::STAZeroPage(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::STAZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::STA, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::STXAbsolute(am) => {
+                Instruction::new(mnemonic::STX, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::STXZeroPage(am) => {
+                Instruction::new(mnemonic::STX, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::STXZeroPageIndexedWithY(am) => {
+                Instruction::new(mnemonic::STX, addressing_mode::ZeroPageIndexedWithY(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::STYAbsolute(am) => {
+                Instruction::new(mnemonic::STY, addressing_mode::Absolute(am)).generate(cpu)
+            }
+            InstructionVariant::STYZeroPage(am) => {
+                Instruction::new(mnemonic::STY, addressing_mode::ZeroPage(am)).generate(cpu)
+            }
+            InstructionVariant::STYZeroPageIndexedWithX(am) => {
+                Instruction::new(mnemonic::STY, addressing_mode::ZeroPageIndexedWithX(am))
+                    .generate(cpu)
+            }
+            InstructionVariant::SECImplied => {
+                Instruction::new(mnemonic::SEC, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::SEDImplied => {
+                Instruction::new(mnemonic::SED, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::SEIImplied => {
+                Instruction::new(mnemonic::SEI, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TAXImplied => {
+                Instruction::new(mnemonic::TAX, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TAYImplied => {
+                Instruction::new(mnemonic::TAY, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TSXImplied => {
+                Instruction::new(mnemonic::TSX, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TXAImplied => {
+                Instruction::new(mnemonic::TXA, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TXSImplied => {
+                Instruction::new(mnemonic::TXS, addressing_mode::Implied).generate(cpu)
+            }
+            InstructionVariant::TYAImplied => {
+                Instruction::new(mnemonic::TYA, addressing_mode::Implied).generate(cpu)
+            }
+        }
     }
 }
 
-impl std::convert::TryFrom<&[u8; 3]> for Operation {
-    type Error = String;
-    fn try_from(values: &[u8; 3]) -> std::result::Result<Self, Self::Error> {
-        match OperationParser.parse(values) {
-            Ok(parcel::MatchStatus::Match((_, op))) => Ok(op),
-            _ => Err(format!("No match found for {}", values[0])),
-        }
+impl Cyclable for InstructionVariant {
+    fn cycles(&self) -> usize {
+        isa_mos6502::CycleCost::cycles(self)
+    }
+}
+
+impl Offset for InstructionVariant {
+    fn offset(&self) -> usize {
+        isa_mos6502::ByteSized::byte_size(self)
     }
 }
 
 /// Macros to simplify definition of instruction set parsers. by hiding the
 /// process of converting an instruction parser to its corresponding operation
-macro_rules! inst_to_operation {
+macro_rules! inst_to_variant {
     ($inst:expr) => {
         $inst.map(Into::into)
     };
@@ -396,289 +865,289 @@ macro_rules! inst_to_operation {
     };
 }
 
-/// Provides a wrapper type for parsing byte slices into Operations.
-struct OperationParser;
+/// Provides a wrapper type for parsing byte slices into an InstructionVariant.
+pub struct VariantParser;
 
-impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Operation> {
+impl<'a> Parser<'a, &'a [u8], InstructionVariant> for VariantParser {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], InstructionVariant> {
         parcel::one_of(vec![
-            inst_to_operation!(mnemonic::ADC, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ADC, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::ADC,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::ADC,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::ADC, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::ADC, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::ADC, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::ADC, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ADC, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::ADC, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::ADC, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::ADC, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::ADC,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::AND, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::AND, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::AND,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::AND,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::AND, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::AND, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::AND, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::AND, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::AND, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::AND, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::AND, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::AND, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::AND,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::ASL, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ASL, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::ASL,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::ASL, addressing_mode::Accumulator),
-            inst_to_operation!(mnemonic::ASL, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ASL, addressing_mode::Accumulator),
+            inst_to_variant!(mnemonic::ASL, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::ASL,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::BCC, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BCS, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BEQ, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BMI, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BIT, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::BIT, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(mnemonic::BNE, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BPL, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BRK, addressing_mode::Implied::default()),
-            inst_to_operation!(mnemonic::BVC, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::BVS, addressing_mode::Relative::default()),
-            inst_to_operation!(mnemonic::CLC, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::CLD, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::CLI, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::CLV, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::CMP, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::BCC, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BCS, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BEQ, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BMI, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BIT, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::BIT, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(mnemonic::BNE, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BPL, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BRK, addressing_mode::Implied::default()),
+            inst_to_variant!(mnemonic::BVC, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::BVS, addressing_mode::Relative::default()),
+            inst_to_variant!(mnemonic::CLC, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::CLD, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::CLI, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::CLV, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::CMP, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::CMP,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::CMP,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::CMP, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::CMP, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::CMP, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::CMP, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::CMP, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::CMP, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::CMP, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::CMP, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::CMP,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::CPX, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::CPX, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::CPX, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(mnemonic::CPY, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::CPY, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::CPY, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(mnemonic::DEC, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::CPX, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::CPX, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::CPX, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(mnemonic::CPY, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::CPY, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::CPY, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(mnemonic::DEC, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::DEC,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::DEC, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::DEC, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::DEC,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::DEX, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::DEY, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::EOR, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::DEX, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::DEY, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::EOR, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::EOR,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::EOR,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::EOR, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::EOR, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::EOR, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::EOR, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::EOR, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::EOR, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::EOR, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::EOR, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::EOR,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::INC, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::INC, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::INC,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::INC, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::INC, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::INC,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::INX, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::INY, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::JMP, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::JMP, addressing_mode::Indirect::default()),
-            inst_to_operation!(mnemonic::JSR, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::LDA, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::INX, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::INY, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::JMP, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::JMP, addressing_mode::Indirect::default()),
+            inst_to_variant!(mnemonic::JSR, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::LDA, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::LDA,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::LDA,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::LDA, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::LDA, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::LDA, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::LDA, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LDA, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::LDA, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::LDA, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::LDA, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::LDA,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::LDX, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LDX, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::LDX,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::LDX, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::LDX, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LDX, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::LDX, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::LDX,
                 addressing_mode::ZeroPageIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::LDY, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LDY, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::LDY,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::LDY, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::LDY, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LDY, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::LDY, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::LDY,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::LSR, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LSR, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::LSR,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::LSR, addressing_mode::Accumulator),
-            inst_to_operation!(mnemonic::LSR, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::LSR, addressing_mode::Accumulator),
+            inst_to_variant!(mnemonic::LSR, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::LSR,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::NOP, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::ORA, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::NOP, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::ORA, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::ORA,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::ORA,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::ORA, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::ORA, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::ORA, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::ORA, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ORA, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::ORA, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::ORA, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::ORA, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::ORA,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::PHA, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::PHP, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::PLA, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::PLP, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::ROL, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::PHA, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::PHP, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::PLA, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::PLP, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::ROL, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::ROL,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::ROL, addressing_mode::Accumulator),
-            inst_to_operation!(mnemonic::ROL, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ROL, addressing_mode::Accumulator),
+            inst_to_variant!(mnemonic::ROL, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::ROL,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::ROR, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ROR, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::ROR,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::ROR, addressing_mode::Accumulator),
-            inst_to_operation!(mnemonic::ROR, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::ROR, addressing_mode::Accumulator),
+            inst_to_variant!(mnemonic::ROR, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::ROR,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::RTI, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::RTS, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::SBC, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::RTI, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::RTS, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::SBC, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::SBC,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::SBC,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::SBC, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::SBC, addressing_mode::Immediate::default()),
-            inst_to_operation!(mnemonic::SBC, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::SBC, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::SBC, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::SBC, addressing_mode::Immediate::default()),
+            inst_to_variant!(mnemonic::SBC, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::SBC, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::SBC,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::STA, addressing_mode::Absolute::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::STA, addressing_mode::Absolute::default()),
+            inst_to_variant!(
                 mnemonic::STA,
                 addressing_mode::AbsoluteIndexedWithX::default()
             ),
-            inst_to_operation!(
+            inst_to_variant!(
                 mnemonic::STA,
                 addressing_mode::AbsoluteIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::STA, addressing_mode::IndirectYIndexed::default()),
-            inst_to_operation!(mnemonic::STA, addressing_mode::XIndexedIndirect::default()),
-            inst_to_operation!(mnemonic::STA, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::STA, addressing_mode::IndirectYIndexed::default()),
+            inst_to_variant!(mnemonic::STA, addressing_mode::XIndexedIndirect::default()),
+            inst_to_variant!(mnemonic::STA, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::STA,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::STX, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::STX, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::STX, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::STX, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::STX,
                 addressing_mode::ZeroPageIndexedWithY::default()
             ),
-            inst_to_operation!(mnemonic::STY, addressing_mode::Absolute::default()),
-            inst_to_operation!(mnemonic::STY, addressing_mode::ZeroPage::default()),
-            inst_to_operation!(
+            inst_to_variant!(mnemonic::STY, addressing_mode::Absolute::default()),
+            inst_to_variant!(mnemonic::STY, addressing_mode::ZeroPage::default()),
+            inst_to_variant!(
                 mnemonic::STY,
                 addressing_mode::ZeroPageIndexedWithX::default()
             ),
-            inst_to_operation!(mnemonic::SEC, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::SED, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::SEI, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TAX, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TAY, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TSX, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TXA, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TXS, addressing_mode::Implied),
-            inst_to_operation!(mnemonic::TYA, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::SEC, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::SED, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::SEI, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TAX, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TAY, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TSX, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TXA, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TXS, addressing_mode::Implied),
+            inst_to_variant!(mnemonic::TYA, addressing_mode::Implied),
         ])
         .parse(input)
     }
@@ -690,7 +1159,8 @@ where
     A: Copy + Debug + PartialEq + isa_mos6502::ByteSized,
 {
     fn offset(&self) -> usize {
-        self.mnemonic.byte_size() + self.addressing_mode.byte_size()
+        isa_mos6502::ByteSized::byte_size(&self.mnemonic)
+            + isa_mos6502::ByteSized::byte_size(&self.addressing_mode)
     }
 }
 
@@ -702,21 +1172,6 @@ where
 {
     fn cycles(&self) -> usize {
         isa_mos6502::CycleCost::cycles(self)
-    }
-}
-
-impl<M, A> Into<Operation> for Instruction<M, A>
-where
-    M: Copy + Debug + PartialEq + isa_mos6502::ByteSized + 'static,
-    A: Copy + Debug + PartialEq + isa_mos6502::ByteSized + 'static,
-    Self: Generate<MOS6502, MOps> + Cyclable + 'static,
-{
-    fn into(self) -> Operation {
-        Operation::new(
-            self.offset(),
-            self.cycles(),
-            Box::new(move |cpu| self.generate(cpu)),
-        )
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -5,7 +5,7 @@ use crate::address_map::{
 use crate::cpu::{
     mos6502::{
         microcode::*,
-        operations::MOps,
+        operations::Operations,
         register::{
             ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter,
             ProgramStatusFlags, StackPointer, WordRegisters,
@@ -29,7 +29,7 @@ fn should_generate_absolute_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -56,7 +56,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -83,7 +83,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -112,7 +112,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -136,7 +136,7 @@ fn should_generate_immediate_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -165,7 +165,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -191,7 +191,7 @@ fn should_generate_zeropage_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -218,7 +218,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_adc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -245,7 +245,7 @@ fn should_generate_absolute_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -269,7 +269,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -293,7 +293,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -320,7 +320,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -342,7 +342,7 @@ fn should_generate_immediate_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -369,7 +369,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -392,7 +392,7 @@ fn should_generate_zeropage_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -416,7 +416,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -440,7 +440,7 @@ fn should_generate_absolute_addressing_mode_asl_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -464,7 +464,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -487,7 +487,7 @@ fn should_generate_accumulator_addressing_mode_asl_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -510,7 +510,7 @@ fn should_generate_zeropage_addressing_mode_asl_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -534,7 +534,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_asl_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -563,7 +563,7 @@ fn should_generate_bcc_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -585,7 +585,7 @@ fn should_generate_bcc_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -606,7 +606,7 @@ fn should_generate_bcc_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -630,7 +630,7 @@ fn should_generate_bcs_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -652,7 +652,7 @@ fn should_generate_bcs_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -673,7 +673,7 @@ fn should_generate_bcs_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -697,7 +697,7 @@ fn should_generate_beq_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -719,7 +719,7 @@ fn should_generate_beq_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -740,7 +740,7 @@ fn should_generate_beq_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -764,7 +764,7 @@ fn should_generate_bmi_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -786,7 +786,7 @@ fn should_generate_bmi_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -807,7 +807,7 @@ fn should_generate_bmi_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -828,7 +828,7 @@ fn should_generate_absolute_addressing_mode_bit_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -851,7 +851,7 @@ fn should_generate_zeropage_addressing_mode_bit_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -879,7 +879,7 @@ fn should_generate_bne_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -901,7 +901,7 @@ fn should_generate_bne_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -922,7 +922,7 @@ fn should_generate_bne_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -946,7 +946,7 @@ fn should_generate_bpl_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -968,7 +968,7 @@ fn should_generate_bpl_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -989,7 +989,7 @@ fn should_generate_bpl_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1024,7 +1024,7 @@ fn should_generate_implied_addressing_mode_brk_machine_code() {
     let expected_ps_on_stack = ProcessorStatus::with_value(0b00100000);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0, // PC controlled by the instruction
             7,
             vec![
@@ -1058,7 +1058,7 @@ fn should_generate_bvc_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1080,7 +1080,7 @@ fn should_generate_bvc_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1101,7 +1101,7 @@ fn should_generate_bvc_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1125,7 +1125,7 @@ fn should_generate_bvs_machine_code_with_branch_penalty() {
     let pc = cpu.pc.read() + 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1147,7 +1147,7 @@ fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
     let pc = cpu.pc.read() - 8;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             4,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1168,7 +1168,7 @@ fn should_generate_bvs_machine_code_with_no_jump() {
     let pc = cpu.pc.read() + 2;
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             2,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, pc)]
@@ -1188,7 +1188,7 @@ fn should_generate_implied_addressing_mode_clc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),]
@@ -1208,7 +1208,7 @@ fn should_generate_implied_addressing_mode_cld_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false),]
@@ -1228,7 +1228,7 @@ fn should_generate_implied_addressing_mode_cli_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(
@@ -1251,7 +1251,7 @@ fn should_generate_implied_addressing_mode_clv_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false)]
@@ -1275,7 +1275,7 @@ fn should_generate_absolute_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(3, 4, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
 }
 
 #[test]
@@ -1295,7 +1295,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(3, 4, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
 }
 
 #[test]
@@ -1315,7 +1315,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(3, 4, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
 }
 
 #[test]
@@ -1332,7 +1332,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_cmp_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -1358,7 +1358,7 @@ fn should_generate_immediate_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(2, 2, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(2, 2, expected_mops.clone()), mc);
 }
 
 #[test]
@@ -1375,7 +1375,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_cmp_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -1401,7 +1401,7 @@ fn should_generate_zeropage_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(2, 3, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(2, 3, expected_mops.clone()), mc);
 }
 
 #[test]
@@ -1421,7 +1421,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_cmp_machine_code() {
         gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
-    assert_eq!(MOps::new(2, 4, expected_mops.clone()), mc);
+    assert_eq!(Operations::new(2, 4, expected_mops.clone()), mc);
 }
 
 // CPX
@@ -1434,7 +1434,7 @@ fn should_generate_absolute_addressing_mode_cpx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -1456,7 +1456,7 @@ fn should_generate_immediate_addressing_mode_cpx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -1478,7 +1478,7 @@ fn should_generate_zeropage_addressing_mode_cpx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -1501,7 +1501,7 @@ fn should_generate_absolute_addressing_mode_cpy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -1523,7 +1523,7 @@ fn should_generate_immediate_addressing_mode_cpy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -1545,7 +1545,7 @@ fn should_generate_zeropage_addressing_mode_cpy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -1569,7 +1569,7 @@ fn should_generate_absolute_addressing_mode_dec_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -1592,7 +1592,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_dec_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -1614,7 +1614,7 @@ fn should_generate_zeropage_addressing_mode_dec_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -1637,7 +1637,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_dec_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -1659,7 +1659,7 @@ fn should_generate_implied_addressing_mode_dex_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -1681,7 +1681,7 @@ fn should_generate_implied_addressing_mode_dey_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -1706,7 +1706,7 @@ fn should_generate_absolute_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -1730,7 +1730,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -1754,7 +1754,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -1781,7 +1781,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -1803,7 +1803,7 @@ fn should_generate_immediate_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -1830,7 +1830,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -1853,7 +1853,7 @@ fn should_generate_zeropage_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -1877,7 +1877,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_eor_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -1901,7 +1901,7 @@ fn should_generate_absolute_addressing_mode_inc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -1924,7 +1924,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_inc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -1946,7 +1946,7 @@ fn should_generate_zeropage_addressing_mode_inc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -1969,7 +1969,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_inc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -1991,7 +1991,7 @@ fn should_generate_implied_addressing_mode_inx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -2013,7 +2013,7 @@ fn should_generate_implied_addressing_mode_iny_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -2037,7 +2037,7 @@ fn should_generate_absolute_addressing_mode_jmp_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0,
             3,
             vec![gen_write_16bit_register_microcode!(WordRegisters::PC, addr)]
@@ -2058,7 +2058,7 @@ fn should_generate_indirect_addressing_mode_jmp_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0, // offset modified directly by operation
             5,
             vec![gen_write_16bit_register_microcode!(
@@ -2085,7 +2085,7 @@ fn should_generate_absolute_addressing_mode_jsr_machine_code() {
     let [pcl, pch] = cpu.pc.read().wrapping_add(2).to_le_bytes();
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             0, // offset modified directly by instruction
             6,
             vec![
@@ -2110,7 +2110,7 @@ fn should_generate_immediate_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -2131,7 +2131,7 @@ fn should_generate_zeropage_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -2172,7 +2172,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -2212,7 +2212,7 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2248,7 +2248,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2284,7 +2284,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2325,7 +2325,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -2351,7 +2351,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_lda_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -2374,7 +2374,7 @@ fn should_generate_absolute_addressing_mode_ldx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2395,7 +2395,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ldx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2416,7 +2416,7 @@ fn should_generate_immediate_addressing_mode_ldx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -2437,7 +2437,7 @@ fn should_generate_zeropage_addressing_mode_ldx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -2463,7 +2463,7 @@ fn should_generate_zeropage_indexed_with_y_addressing_mode_ldx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -2489,7 +2489,7 @@ fn should_generate_absolute_addressing_mode_ldy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2510,7 +2510,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ldy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2531,7 +2531,7 @@ fn should_generate_immediate_addressing_mode_ldy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -2552,7 +2552,7 @@ fn should_generate_zeropage_addressing_mode_ldy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -2578,7 +2578,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ldy_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -2605,7 +2605,7 @@ fn should_generate_absolute_addressing_mode_lsr_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -2629,7 +2629,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lsr_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -2652,7 +2652,7 @@ fn should_generate_accumulator_addressing_mode_lsr_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -2675,7 +2675,7 @@ fn should_generate_zeropage_addressing_mode_lsr_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -2699,7 +2699,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lsr_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -2721,7 +2721,7 @@ fn should_generate_implied_addressing_mode_nop_machine_code() {
     let op: InstructionVariant = Instruction::new(mnemonic::NOP, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
-    assert_eq!(MOps::new(1, 2, vec![]), mc);
+    assert_eq!(Operations::new(1, 2, vec![]), mc);
 }
 
 // ORA
@@ -2736,7 +2736,7 @@ fn should_generate_absolute_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2760,7 +2760,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2784,7 +2784,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -2811,7 +2811,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -2833,7 +2833,7 @@ fn should_generate_immediate_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -2860,7 +2860,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -2883,7 +2883,7 @@ fn should_generate_zeropage_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -2907,7 +2907,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ora_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -2932,7 +2932,7 @@ fn should_generate_implied_addressing_mode_pha_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             3,
             vec![
@@ -2957,7 +2957,7 @@ fn should_generate_implied_addressing_mode_php_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             3,
             vec![
@@ -3045,7 +3045,7 @@ fn should_generate_absolute_addressing_mode_rol_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -3074,7 +3074,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_rol_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -3102,7 +3102,7 @@ fn should_generate_accumulator_addressing_mode_rol_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -3129,7 +3129,7 @@ fn should_generate_zeropage_addressing_mode_rol_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -3158,7 +3158,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_rol_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -3187,7 +3187,7 @@ fn should_generate_absolute_addressing_mode_ror_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             6,
             vec![
@@ -3216,7 +3216,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ror_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             7,
             vec![
@@ -3244,7 +3244,7 @@ fn should_generate_accumulator_addressing_mode_ror_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -3271,7 +3271,7 @@ fn should_generate_zeropage_addressing_mode_ror_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -3300,7 +3300,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ror_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -3334,7 +3334,7 @@ fn should_generate_implied_addressing_mode_rti_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             6,
             vec![
@@ -3360,7 +3360,7 @@ fn should_generate_implied_addressing_mode_rts_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             6,
             vec![
@@ -3390,7 +3390,7 @@ fn should_generate_absolute_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -3422,7 +3422,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -3454,7 +3454,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![
@@ -3488,7 +3488,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             5,
             vec![
@@ -3518,7 +3518,7 @@ fn should_generate_immediate_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             2,
             vec![
@@ -3552,7 +3552,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![
@@ -3583,7 +3583,7 @@ fn should_generate_zeropage_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![
@@ -3615,7 +3615,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_sbc_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![
@@ -3641,7 +3641,7 @@ fn should_generate_implied_addressing_mode_sec_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),]
@@ -3661,7 +3661,7 @@ fn should_generate_implied_addressing_mode_sed_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true),]
@@ -3681,7 +3681,7 @@ fn should_generate_implied_addressing_mode_sei_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),]
@@ -3700,7 +3700,7 @@ fn should_generate_absolute_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00))]
@@ -3719,7 +3719,7 @@ fn should_generate_absolute_with_x_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             5,
             vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
@@ -3752,7 +3752,7 @@ fn should_generate_absolute_with_y_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             5,
             vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
@@ -3788,7 +3788,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
@@ -3810,7 +3810,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             6,
             vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
@@ -3827,7 +3827,7 @@ fn should_generate_zeropage_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x00))]
@@ -3846,7 +3846,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
@@ -3863,7 +3863,7 @@ fn should_generate_absolute_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x55))]
@@ -3880,7 +3880,7 @@ fn should_generate_zeropage_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x55))]
@@ -3899,7 +3899,7 @@ fn should_generate_zeropage_with_y_index_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0x55))]
@@ -3916,7 +3916,7 @@ fn should_generate_absolute_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             3,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x55))]
@@ -3933,7 +3933,7 @@ fn should_generate_zeropage_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             3,
             vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x55))]
@@ -3952,7 +3952,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             2,
             4,
             vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0x55))]
@@ -3969,7 +3969,7 @@ fn should_generate_implied_addressing_mode_tax_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -3990,7 +3990,7 @@ fn should_generate_implied_addressing_mode_tay_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -4010,7 +4010,7 @@ fn should_generate_implied_addressing_mode_tsx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -4030,7 +4030,7 @@ fn should_generate_implied_addressing_mode_txa_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![
@@ -4050,7 +4050,7 @@ fn should_generate_implied_addressing_mode_txs_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![gen_write_8bit_register_microcode!(ByteRegisters::SP, 0x00)]
@@ -4066,7 +4066,7 @@ fn should_generate_implied_addressing_mode_tya_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        MOps::new(
+        Operations::new(
             1,
             2,
             vec![

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -5,7 +5,7 @@ use crate::address_map::{
 use crate::cpu::{
     mos6502::{
         microcode::*,
-        operations::{Instruction, MOps, Operation},
+        operations::MOps,
         register::{
             ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter,
             ProgramStatusFlags, StackPointer, WordRegisters,
@@ -14,7 +14,7 @@ use crate::cpu::{
     },
     register::Register,
 };
-use isa_mos6502::{addressing_mode, mnemonic};
+use isa_mos6502::{addressing_mode, mnemonic, Instruction, InstructionVariant};
 
 // ADC
 
@@ -23,7 +23,8 @@ fn should_generate_absolute_addressing_mode_adc_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ADC, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ADC, addressing_mode::Absolute(0x00ff)).into();
 
     let mc = op.generate(&cpu);
 
@@ -49,7 +50,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_adc_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ADC, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
 
     let mc = op.generate(&cpu);
@@ -76,7 +77,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_adc_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ADC, addressing_mode::AbsoluteIndexedWithY(0x00fa)).into();
 
     let mc = op.generate(&cpu);
@@ -106,7 +107,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_adc_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xff).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ADC, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -130,7 +131,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_adc_machine_code() {
 fn should_generate_immediate_addressing_mode_adc_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
-    let op: Operation = Instruction::new(mnemonic::ADC, addressing_mode::Immediate(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ADC, addressing_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -158,7 +160,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_adc_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xff).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ADC, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -183,7 +185,8 @@ fn should_generate_zeropage_addressing_mode_adc_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ADC, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ADC, addressing_mode::ZeroPage(0xff)).into();
 
     let mc = op.generate(&cpu);
 
@@ -209,7 +212,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_adc_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x80))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0xff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ADC, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
 
     let mc = op.generate(&cpu);
@@ -237,7 +240,8 @@ fn should_generate_absolute_addressing_mode_and_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::AND, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::AND, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -260,7 +264,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_and_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::AND, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -284,7 +288,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_and_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::AND, addressing_mode::AbsoluteIndexedWithY(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -311,7 +315,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_and_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::AND, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -333,7 +337,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_and_machine_code() {
 fn should_generate_immediate_addressing_mode_and_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::AND, addressing_mode::Immediate(0x55)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::AND, addressing_mode::Immediate(0x55)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -359,7 +364,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_and_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::AND, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -382,7 +387,8 @@ fn should_generate_zeropage_addressing_mode_and_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::AND, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::AND, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -405,7 +411,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::AND, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -429,7 +435,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
 fn should_generate_absolute_addressing_mode_asl_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ASL, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -452,7 +459,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ASL, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -475,7 +482,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
 fn should_generate_accumulator_addressing_mode_asl_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xaa));
-    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::Accumulator).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ASL, addressing_mode::Accumulator).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -497,7 +505,8 @@ fn should_generate_accumulator_addressing_mode_asl_machine_code() {
 fn should_generate_zeropage_addressing_mode_asl_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ASL, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ASL, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -520,7 +529,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_asl_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ASL, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -546,7 +555,8 @@ fn should_generate_bcc_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = false;
 
-    let op: Operation = Instruction::new(mnemonic::BCC, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCC, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -567,7 +577,8 @@ fn should_generate_bcc_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = false;
 
-    let op: Operation = Instruction::new(mnemonic::BCC, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCC, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -588,7 +599,8 @@ fn should_generate_bcc_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = true;
 
-    let op: Operation = Instruction::new(mnemonic::BCC, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCC, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -610,7 +622,8 @@ fn should_generate_bcs_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = true;
 
-    let op: Operation = Instruction::new(mnemonic::BCS, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCS, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -631,7 +644,8 @@ fn should_generate_bcs_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = true;
 
-    let op: Operation = Instruction::new(mnemonic::BCS, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCS, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -652,7 +666,8 @@ fn should_generate_bcs_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.carry = false;
 
-    let op: Operation = Instruction::new(mnemonic::BCS, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BCS, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -674,7 +689,8 @@ fn should_generate_beq_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = true;
 
-    let op: Operation = Instruction::new(mnemonic::BEQ, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BEQ, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -695,7 +711,8 @@ fn should_generate_beq_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = true;
 
-    let op: Operation = Instruction::new(mnemonic::BEQ, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BEQ, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -716,7 +733,8 @@ fn should_generate_beq_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = false;
 
-    let op: Operation = Instruction::new(mnemonic::BEQ, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BEQ, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -738,7 +756,8 @@ fn should_generate_bmi_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = true;
 
-    let op: Operation = Instruction::new(mnemonic::BMI, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BMI, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc + relative address
@@ -759,7 +778,8 @@ fn should_generate_bmi_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = true;
 
-    let op: Operation = Instruction::new(mnemonic::BMI, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BMI, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -780,7 +800,8 @@ fn should_generate_bmi_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = false;
 
-    let op: Operation = Instruction::new(mnemonic::BMI, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BMI, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -802,7 +823,8 @@ fn should_generate_absolute_addressing_mode_bit_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::BIT, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BIT, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -824,7 +846,8 @@ fn should_generate_zeropage_addressing_mode_bit_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::BIT, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BIT, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -848,7 +871,8 @@ fn should_generate_bne_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = false;
 
-    let op: Operation = Instruction::new(mnemonic::BNE, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BNE, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc + relative address
@@ -869,7 +893,8 @@ fn should_generate_bne_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = false;
 
-    let op: Operation = Instruction::new(mnemonic::BNE, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BNE, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -890,7 +915,8 @@ fn should_generate_bne_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.zero = true;
 
-    let op: Operation = Instruction::new(mnemonic::BNE, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BNE, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -912,7 +938,8 @@ fn should_generate_bpl_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = false;
 
-    let op: Operation = Instruction::new(mnemonic::BPL, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BPL, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc + relative address
@@ -933,7 +960,8 @@ fn should_generate_bpl_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = false;
 
-    let op: Operation = Instruction::new(mnemonic::BPL, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BPL, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -954,7 +982,8 @@ fn should_generate_bpl_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.negative = true;
 
-    let op: Operation = Instruction::new(mnemonic::BPL, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BPL, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -988,7 +1017,7 @@ fn should_generate_implied_addressing_mode_brk_machine_code() {
         )
         .unwrap();
 
-    let op: Operation = Instruction::new(mnemonic::BRK, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::BRK, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     // expect unused flag to be set only for status register on stack.
@@ -1021,7 +1050,8 @@ fn should_generate_bvc_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = false;
 
-    let op: Operation = Instruction::new(mnemonic::BVC, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVC, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc + relative address
@@ -1042,7 +1072,8 @@ fn should_generate_bvc_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = false;
 
-    let op: Operation = Instruction::new(mnemonic::BVC, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVC, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -1063,7 +1094,8 @@ fn should_generate_bvc_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = true;
 
-    let op: Operation = Instruction::new(mnemonic::BVC, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVC, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -1085,7 +1117,8 @@ fn should_generate_bvs_machine_code_with_branch_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = true;
 
-    let op: Operation = Instruction::new(mnemonic::BVS, addressing_mode::Relative(8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVS, addressing_mode::Relative(8)).into();
     let mc = op.generate(&cpu);
 
     // pc + relative address
@@ -1106,7 +1139,8 @@ fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = true;
 
-    let op: Operation = Instruction::new(mnemonic::BVS, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVS, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     // pc - relative address
@@ -1127,7 +1161,8 @@ fn should_generate_bvs_machine_code_with_no_jump() {
     let mut cpu = MOS6502::default().with_pc_register(ProgramCounter::with_value(0x6000));
     cpu.ps.overflow = false;
 
-    let op: Operation = Instruction::new(mnemonic::BVS, addressing_mode::Relative(-8)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::BVS, addressing_mode::Relative(-8)).into();
     let mc = op.generate(&cpu);
 
     let pc = cpu.pc.read() + 2;
@@ -1149,7 +1184,7 @@ fn should_generate_implied_addressing_mode_clc_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.carry = true;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::CLC, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::CLC, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1169,7 +1204,7 @@ fn should_generate_implied_addressing_mode_cld_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.carry = true;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::CLD, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::CLD, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1189,7 +1224,7 @@ fn should_generate_implied_addressing_mode_cli_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.interrupt_disable = true;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::CLI, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::CLI, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1212,7 +1247,7 @@ fn should_generate_implied_addressing_mode_clv_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.overflow = true;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::CLV, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::CLV, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1231,7 +1266,7 @@ fn should_generate_implied_addressing_mode_clv_machine_code() {
 fn should_generate_absolute_addressing_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CMP, addressing_mode::Absolute::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
@@ -1248,7 +1283,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_cmp_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
-    let op: Operation = Instruction::new(
+    let op: InstructionVariant = Instruction::new(
         mnemonic::CMP,
         addressing_mode::AbsoluteIndexedWithX::default(),
     )
@@ -1268,7 +1303,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_cmp_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
-    let op: Operation = Instruction::new(
+    let op: InstructionVariant = Instruction::new(
         mnemonic::CMP,
         addressing_mode::AbsoluteIndexedWithY::default(),
     )
@@ -1292,7 +1327,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_cmp_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CMP, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -1314,7 +1349,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_cmp_machine_code() {
 fn should_generate_immediate_addressing_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CMP, addressing_mode::Immediate::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
@@ -1335,7 +1370,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_cmp_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CMP, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -1357,7 +1392,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_cmp_machine_code() {
 fn should_generate_zeropage_addressing_mode_cmp_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CMP, addressing_mode::ZeroPage::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
@@ -1374,7 +1409,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_cmp_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    let op: Operation = Instruction::new(
+    let op: InstructionVariant = Instruction::new(
         mnemonic::CMP,
         addressing_mode::ZeroPageIndexedWithX::default(),
     )
@@ -1394,7 +1429,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_cmp_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_cpx_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPX, addressing_mode::Absolute::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1416,7 +1451,7 @@ fn should_generate_absolute_addressing_mode_cpx_machine_code() {
 fn should_generate_immediate_addressing_mode_cpx_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPX, addressing_mode::Immediate::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1438,7 +1473,7 @@ fn should_generate_immediate_addressing_mode_cpx_machine_code() {
 fn should_generate_zeropage_addressing_mode_cpx_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPX, addressing_mode::ZeroPage::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1461,7 +1496,7 @@ fn should_generate_zeropage_addressing_mode_cpx_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_cpy_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPY, addressing_mode::Absolute::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1483,7 +1518,7 @@ fn should_generate_absolute_addressing_mode_cpy_machine_code() {
 fn should_generate_immediate_addressing_mode_cpy_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPY, addressing_mode::Immediate::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1505,7 +1540,7 @@ fn should_generate_immediate_addressing_mode_cpy_machine_code() {
 fn should_generate_zeropage_addressing_mode_cpy_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x00));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::CPY, addressing_mode::ZeroPage::default()).into();
     let mc = op.generate(&cpu);
 
@@ -1529,7 +1564,8 @@ fn should_generate_zeropage_addressing_mode_cpy_machine_code() {
 fn should_generate_absolute_addressing_mode_dec_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x01ff, 0x05).unwrap();
-    let op: Operation = Instruction::new(mnemonic::DEC, addressing_mode::Absolute(0x01ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::DEC, addressing_mode::Absolute(0x01ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1551,7 +1587,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_dec_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x01ff, 0x05).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::DEC, addressing_mode::AbsoluteIndexedWithX(0x01fa)).into();
     let mc = op.generate(&cpu);
 
@@ -1573,7 +1609,8 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_dec_machine_code() {
 fn should_generate_zeropage_addressing_mode_dec_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0xff, 0x05).unwrap();
-    let op: Operation = Instruction::new(mnemonic::DEC, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::DEC, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1595,7 +1632,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_dec_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0xff, 0x05).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::DEC, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -1618,7 +1655,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_dec_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_dex_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::DEX, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::DEX, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1640,7 +1677,7 @@ fn should_generate_implied_addressing_mode_dex_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_dey_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::DEY, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::DEY, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1664,7 +1701,8 @@ fn should_generate_absolute_addressing_mode_eor_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::EOR, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::EOR, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1687,7 +1725,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_eor_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::EOR, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -1711,7 +1749,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_eor_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::EOR, addressing_mode::AbsoluteIndexedWithY(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -1738,7 +1776,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_eor_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::EOR, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -1760,7 +1798,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_eor_machine_code() {
 fn should_generate_immediate_addressing_mode_eor_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::EOR, addressing_mode::Immediate(0x55)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::EOR, addressing_mode::Immediate(0x55)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1786,7 +1825,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_eor_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::EOR, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -1809,7 +1848,8 @@ fn should_generate_zeropage_addressing_mode_eor_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::EOR, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::EOR, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1832,7 +1872,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_eor_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::EOR, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -1856,7 +1896,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_eor_machine_code() {
 fn should_generate_absolute_addressing_mode_inc_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x01ff, 0x05).unwrap();
-    let op: Operation = Instruction::new(mnemonic::INC, addressing_mode::Absolute(0x01ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::INC, addressing_mode::Absolute(0x01ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1878,7 +1919,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_inc_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x01ff, 0x05).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::INC, addressing_mode::AbsoluteIndexedWithX(0x01fa)).into();
     let mc = op.generate(&cpu);
 
@@ -1900,7 +1941,8 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_inc_machine_code() {
 fn should_generate_zeropage_addressing_mode_inc_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0xff, 0x05).unwrap();
-    let op: Operation = Instruction::new(mnemonic::INC, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::INC, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1922,7 +1964,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_inc_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0xff, 0x05).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::INC, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -1945,7 +1987,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_inc_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_inx_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x12));
-    let op: Operation = Instruction::new(mnemonic::INX, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::INX, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1967,7 +2009,7 @@ fn should_generate_implied_addressing_mode_inx_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_iny_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x12));
-    let op: Operation = Instruction::new(mnemonic::INY, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::INY, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -1990,7 +2032,8 @@ fn should_generate_implied_addressing_mode_iny_machine_code() {
 fn should_generate_absolute_addressing_mode_jmp_machine_code() {
     let cpu = MOS6502::default();
     let addr = 0x0100;
-    let op: Operation = Instruction::new(mnemonic::JMP, addressing_mode::Absolute(addr)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::JMP, addressing_mode::Absolute(addr)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2010,7 +2053,7 @@ fn should_generate_indirect_addressing_mode_jmp_machine_code() {
     let indirect_addr = 0x0150;
     cpu.address_map.write(base_addr, 0x50).unwrap();
     cpu.address_map.write(base_addr + 1, 0x01).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::JMP, addressing_mode::Indirect(base_addr)).into();
     let mc = op.generate(&cpu);
 
@@ -2033,7 +2076,8 @@ fn should_generate_indirect_addressing_mode_jmp_machine_code() {
 fn should_generate_absolute_addressing_mode_jsr_machine_code() {
     let cpu = MOS6502::default();
     let addr = 0x0100;
-    let op: Operation = Instruction::new(mnemonic::JSR, addressing_mode::Absolute(addr)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::JSR, addressing_mode::Absolute(addr)).into();
     let mc = op.generate(&cpu);
 
     let sph: u16 = 0x0100 + cpu.sp.read() as u16;
@@ -2061,7 +2105,8 @@ fn should_generate_absolute_addressing_mode_jsr_machine_code() {
 #[test]
 fn should_generate_immediate_addressing_mode_lda_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDA, addressing_mode::Immediate(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDA, addressing_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2081,7 +2126,8 @@ fn should_generate_immediate_addressing_mode_lda_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_lda_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDA, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDA, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2121,7 +2167,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x05, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDA, addressing_mode::ZeroPageIndexedWithX(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2161,7 +2207,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_lda_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDA, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDA, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2196,7 +2243,7 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
 #[test]
 fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDA, addressing_mode::AbsoluteIndexedWithX(0x0100)).into();
     let mc = op.generate(&cpu);
 
@@ -2232,7 +2279,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
 #[test]
 fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDA, addressing_mode::AbsoluteIndexedWithY(0x0100)).into();
     let mc = op.generate(&cpu);
 
@@ -2273,7 +2320,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_lda_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDA, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2299,7 +2346,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_lda_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xea).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDA, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2322,7 +2369,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_lda_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_ldx_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDX, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDX, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2342,7 +2390,7 @@ fn should_generate_absolute_addressing_mode_ldx_machine_code() {
 #[test]
 fn should_generate_absolute_indexed_with_y_addressing_mode_ldx_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDX, addressing_mode::AbsoluteIndexedWithY(0x0100)).into();
     let mc = op.generate(&cpu);
 
@@ -2363,7 +2411,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ldx_machine_code() {
 #[test]
 fn should_generate_immediate_addressing_mode_ldx_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDX, addressing_mode::Immediate(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDX, addressing_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2383,7 +2432,8 @@ fn should_generate_immediate_addressing_mode_ldx_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_ldx_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDX, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDX, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2408,7 +2458,7 @@ fn should_generate_zeropage_indexed_with_y_addressing_mode_ldx_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x05, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDX, addressing_mode::ZeroPageIndexedWithY(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2434,7 +2484,8 @@ fn should_generate_zeropage_indexed_with_y_addressing_mode_ldx_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_ldy_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDY, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDY, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2454,7 +2505,7 @@ fn should_generate_absolute_addressing_mode_ldy_machine_code() {
 #[test]
 fn should_generate_absolute_indexed_with_x_addressing_mode_ldy_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDY, addressing_mode::AbsoluteIndexedWithX(0x0100)).into();
     let mc = op.generate(&cpu);
 
@@ -2475,7 +2526,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ldy_machine_code() {
 #[test]
 fn should_generate_immediate_addressing_mode_ldy_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDY, addressing_mode::Immediate(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDY, addressing_mode::Immediate(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2495,7 +2547,8 @@ fn should_generate_immediate_addressing_mode_ldy_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_ldy_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::LDY, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LDY, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2520,7 +2573,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ldy_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x05, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LDY, addressing_mode::ZeroPageIndexedWithX(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2547,7 +2600,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ldy_machine_code() {
 fn should_generate_absolute_addressing_mode_lsr_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::LSR, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LSR, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2570,7 +2624,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lsr_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LSR, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -2593,7 +2647,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lsr_machine_code() {
 fn should_generate_accumulator_addressing_mode_lsr_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::LSR, addressing_mode::Accumulator).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LSR, addressing_mode::Accumulator).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2615,7 +2670,8 @@ fn should_generate_accumulator_addressing_mode_lsr_machine_code() {
 fn should_generate_zeropage_addressing_mode_lsr_machine_code() {
     let mut cpu = MOS6502::default();
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::LSR, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::LSR, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2638,7 +2694,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lsr_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::LSR, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -2662,7 +2718,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lsr_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_nop_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::NOP, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::NOP, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(MOps::new(1, 2, vec![]), mc);
@@ -2675,7 +2731,8 @@ fn should_generate_absolute_addressing_mode_ora_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ORA, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ORA, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2698,7 +2755,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ora_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ORA, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -2722,7 +2779,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ora_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0xff).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ORA, addressing_mode::AbsoluteIndexedWithY(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -2749,7 +2806,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_ora_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ORA, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2771,7 +2828,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_ora_machine_code() {
 fn should_generate_immediate_addressing_mode_ora_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::ORA, addressing_mode::Immediate(0x55)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ORA, addressing_mode::Immediate(0x55)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2797,7 +2855,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_ora_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0x55).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ORA, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -2820,7 +2878,8 @@ fn should_generate_zeropage_addressing_mode_ora_machine_code() {
     let mut cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ORA, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ORA, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2843,7 +2902,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ora_machine_code() {
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
     cpu.address_map.write(0x00ff, 0x55).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ORA, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -2869,7 +2928,7 @@ fn should_generate_implied_addressing_mode_pha_machine_code() {
         .reset()
         .unwrap()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::PHA, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::PHA, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2894,7 +2953,7 @@ fn should_generate_implied_addressing_mode_php_machine_code() {
         .reset()
         .unwrap()
         .with_ps_register(ProcessorStatus::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::PHP, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::PHP, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2922,7 +2981,7 @@ fn should_generate_implied_addressing_mode_pla_machine_code() {
         .with_sp_register(StackPointer::with_value(0xfe));
     cpu.address_map.write(0x01ff, 0xff).unwrap();
 
-    let op: Operation = Instruction::new(mnemonic::PLA, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::PLA, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2953,7 +3012,7 @@ fn should_generate_implied_addressing_mode_plp_machine_code() {
         .with_sp_register(StackPointer::with_value(0xfe));
     cpu.address_map.write(0x01ff, 0x55).unwrap();
 
-    let op: Operation = Instruction::new(mnemonic::PLP, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::PLP, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -2981,7 +3040,8 @@ fn should_generate_absolute_addressing_mode_rol_machine_code() {
         ps
     });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROL, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3009,7 +3069,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_rol_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ROL, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -3037,7 +3097,8 @@ fn should_generate_accumulator_addressing_mode_rol_machine_code() {
             ps.carry = true;
             ps
         });
-    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::Accumulator).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROL, addressing_mode::Accumulator).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3063,7 +3124,8 @@ fn should_generate_zeropage_addressing_mode_rol_machine_code() {
         ps
     });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ROL, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROL, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3091,7 +3153,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_rol_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ROL, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -3120,7 +3182,8 @@ fn should_generate_absolute_addressing_mode_ror_machine_code() {
         ps
     });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROR, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3148,7 +3211,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ror_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ROR, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
     let mc = op.generate(&cpu);
 
@@ -3176,7 +3239,8 @@ fn should_generate_accumulator_addressing_mode_ror_machine_code() {
             ps.carry = true;
             ps
         });
-    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::Accumulator).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROR, addressing_mode::Accumulator).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3202,7 +3266,8 @@ fn should_generate_zeropage_addressing_mode_ror_machine_code() {
         ps
     });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation = Instruction::new(mnemonic::ROR, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::ROR, addressing_mode::ZeroPage(0xff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3230,7 +3295,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ror_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xaa).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::ROR, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
     let mc = op.generate(&cpu);
 
@@ -3265,7 +3330,7 @@ fn should_generate_implied_addressing_mode_rti_machine_code() {
         })
         .unwrap();
 
-    let op: Operation = Instruction::new(mnemonic::RTI, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::RTI, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3291,7 +3356,7 @@ fn should_generate_implied_addressing_mode_rts_machine_code() {
     cpu.address_map.write(0x01fe, 0x02).unwrap();
     cpu.address_map.write(0x01ff, 0x60).unwrap();
 
-    let op: Operation = Instruction::new(mnemonic::RTS, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::RTS, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3320,7 +3385,8 @@ fn should_generate_absolute_addressing_mode_sbc_machine_code() {
         });
 
     cpu.address_map.write(0x00ff, 0xb0).unwrap();
-    let op: Operation = Instruction::new(mnemonic::SBC, addressing_mode::Absolute(0x00ff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::SBC, addressing_mode::Absolute(0x00ff)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3350,7 +3416,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_sbc_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xb0).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::SBC, addressing_mode::AbsoluteIndexedWithX(0x00fa)).into();
 
     let mc = op.generate(&cpu);
@@ -3382,7 +3448,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_sbc_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xb0).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::SBC, addressing_mode::AbsoluteIndexedWithY(0x00fa)).into();
 
     let mc = op.generate(&cpu);
@@ -3417,7 +3483,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sbc_machine_code() {
     cpu.address_map.write(0x01, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xb0).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::SBC, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3447,7 +3513,8 @@ fn should_generate_immediate_addressing_mode_sbc_machine_code() {
             ps
         });
 
-    let op: Operation = Instruction::new(mnemonic::SBC, addressing_mode::Immediate(0xb0)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::SBC, addressing_mode::Immediate(0xb0)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3480,7 +3547,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sbc_machine_code() {
     cpu.address_map.write(0x06, 0x00).unwrap();
     cpu.address_map.write(0xff, 0xb0).unwrap(); // indirect addr
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::SBC, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3510,7 +3577,8 @@ fn should_generate_zeropage_addressing_mode_sbc_machine_code() {
             ps
         });
     cpu.address_map.write(0x00ff, 0xb0).unwrap();
-    let op: Operation = Instruction::new(mnemonic::SBC, addressing_mode::ZeroPage(0xff)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::SBC, addressing_mode::ZeroPage(0xff)).into();
 
     let mc = op.generate(&cpu);
 
@@ -3541,7 +3609,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_sbc_machine_code() {
             ps
         });
     cpu.address_map.write(0xff, 0xb0).unwrap();
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::SBC, addressing_mode::ZeroPageIndexedWithX(0xfa)).into();
 
     let mc = op.generate(&cpu);
@@ -3569,7 +3637,7 @@ fn should_generate_implied_addressing_mode_sec_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.carry = false;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::SEC, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::SEC, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3589,7 +3657,7 @@ fn should_generate_implied_addressing_mode_sed_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.decimal = false;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::SED, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::SED, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3609,7 +3677,7 @@ fn should_generate_implied_addressing_mode_sei_machine_code() {
     let mut ps = ProcessorStatus::new();
     ps.interrupt_disable = false;
     let cpu = MOS6502::default().with_ps_register(ps);
-    let op: Operation = Instruction::new(mnemonic::SEI, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::SEI, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3627,7 +3695,8 @@ fn should_generate_implied_addressing_mode_sei_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_sta_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::STA, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STA, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3645,7 +3714,7 @@ fn should_generate_absolute_with_x_index_addressing_mode_sta_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STA, addressing_mode::AbsoluteIndexedWithX(0x0000)).into();
     let mc = op.generate(&cpu);
 
@@ -3678,7 +3747,7 @@ fn should_generate_absolute_with_y_index_addressing_mode_sta_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STA, addressing_mode::AbsoluteIndexedWithY(0x0000)).into();
     let mc = op.generate(&cpu);
 
@@ -3714,7 +3783,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sta_machine_code() {
     cpu.address_map.write(0x00, 0xfa).unwrap();
     cpu.address_map.write(0x01, 0x00).unwrap();
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STA, addressing_mode::IndirectYIndexed(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3736,7 +3805,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sta_machine_code() {
     cpu.address_map.write(0x05, 0xff).unwrap();
     cpu.address_map.write(0x06, 0x00).unwrap();
 
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STA, addressing_mode::XIndexedIndirect(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3753,7 +3822,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_sta_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_sta_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = Instruction::new(mnemonic::STA, addressing_mode::ZeroPage(0x01)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STA, addressing_mode::ZeroPage(0x01)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3771,7 +3841,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sta_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STA, addressing_mode::ZeroPageIndexedWithX(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3788,7 +3858,8 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sta_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_stx_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::STX, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STX, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3804,7 +3875,8 @@ fn should_generate_absolute_addressing_mode_stx_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_stx_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::STX, addressing_mode::ZeroPage(0x01)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STX, addressing_mode::ZeroPage(0x01)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3822,7 +3894,7 @@ fn should_generate_zeropage_with_y_index_addressing_mode_stx_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x55))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x05));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STX, addressing_mode::ZeroPageIndexedWithY(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3839,7 +3911,8 @@ fn should_generate_zeropage_with_y_index_addressing_mode_stx_machine_code() {
 #[test]
 fn should_generate_absolute_addressing_mode_sty_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::STY, addressing_mode::Absolute(0x0100)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STY, addressing_mode::Absolute(0x0100)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3855,7 +3928,8 @@ fn should_generate_absolute_addressing_mode_sty_machine_code() {
 #[test]
 fn should_generate_zeropage_addressing_mode_sty_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x55));
-    let op: Operation = Instruction::new(mnemonic::STY, addressing_mode::ZeroPage(0x01)).into();
+    let op: InstructionVariant =
+        Instruction::new(mnemonic::STY, addressing_mode::ZeroPage(0x01)).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3873,7 +3947,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sty_machine_code() {
     let cpu = MOS6502::default()
         .with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x05))
         .with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x55));
-    let op: Operation =
+    let op: InstructionVariant =
         Instruction::new(mnemonic::STY, addressing_mode::ZeroPageIndexedWithX(0x00)).into();
     let mc = op.generate(&cpu);
 
@@ -3891,7 +3965,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sty_machine_code() {
 fn should_generate_implied_addressing_mode_tax_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::TAX, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TAX, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3912,7 +3986,7 @@ fn should_generate_implied_addressing_mode_tax_machine_code() {
 fn should_generate_implied_addressing_mode_tay_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::TAY, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TAY, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3932,7 +4006,7 @@ fn should_generate_implied_addressing_mode_tay_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_tsx_machine_code() {
     let cpu = MOS6502::default().with_sp_register(StackPointer::default());
-    let op: Operation = Instruction::new(mnemonic::TSX, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TSX, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3952,7 +4026,7 @@ fn should_generate_implied_addressing_mode_tsx_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_txa_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::TXA, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TXA, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3972,7 +4046,7 @@ fn should_generate_implied_addressing_mode_txa_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_txs_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
-    let op: Operation = Instruction::new(mnemonic::TXS, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TXS, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(
@@ -3988,7 +4062,7 @@ fn should_generate_implied_addressing_mode_txs_machine_code() {
 #[test]
 fn should_generate_implied_addressing_mode_tya_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::TYA, addressing_mode::Implied).into();
+    let op: InstructionVariant = Instruction::new(mnemonic::TYA, addressing_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     assert_eq!(


### PR DESCRIPTION
# Introduction
This PR makes use of the `InstructionVariant` type defined in v0.2.0 of ncatelli/isa-mos6502 to convert the `Generate` method from a dynamic dispatched function to a concrete function that is dispatched via a match. This change does not have a significant runtime performance impact however it does bring more of the library in line with the isa-mos6502 library.

before

```
vscode ➜ /workspaces/mainspring (main) $ time ./target/release/examples/basic
MOS6502 { address_map: AddressMap [512..=32767, 0..=255, 65514..=65535, 256..=511], acc: GeneralPurpose { inner: 3 }, x: GeneralPurpose { inner: 0 }, y: GeneralPurpose { inner: 0 }, sp: StackPointer { inner: 255 }, pc: ProgramCounter { inner: 65514 }, ps: ProcessorStatus { carry: false, zero: false, interrupt_disable: false, decimal: false, brk: false, unused: true, overflow: false, negative: false } }

real    0m2.606s
user    0m2.606s
sys     0m0.000s
```

after

```
vscode ➜ /workspaces/mainspring (experiment/operation-to-isa-mos6502-instruction-variant) $ time ./target/release/examples/basic
MOS6502 { address_map: AddressMap [256..=511, 0..=255, 512..=32767, 65514..=65535], acc: GeneralPurpose { inner: 3 }, x: GeneralPurpose { inner: 0 }, y: GeneralPurpose { inner: 0 }, sp: StackPointer { inner: 255 }, pc: ProgramCounter { inner: 65514 }, ps: ProcessorStatus { carry: false, zero: false, interrupt_disable: false, decimal: false, brk: false, unused: true, overflow: false, negative: false } }

real    0m2.565s
user    0m2.561s
sys     0m0.004s
```

In addition, this PR also includes a rename of the `MOps` type from `MOps` -> `Operations` with the removal of the previous `Operations` type which more clearly conveys its purpose.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
