### PR TITLE
Fix duplicate print in custom_peripheral example

### DIFF
--- a/examples/custom_peripheral.rs
+++ b/examples/custom_peripheral.rs
@@ -1,6 +1,7 @@
 //! A small demonstration example of mainspring showing a basic custom Addressable implementation.
 
 use mainspring::address_map::memory::{Memory, ReadOnly};
+use mainspring::cpu::mos6502::microcode::Microcode;
 use mainspring::cpu::mos6502::MOS6502;
 
 #[allow(unused)]
@@ -80,6 +81,12 @@ fn main() {
         // enclosing cpu.
         .unwrap();
 
-    // Runs the program for 40 cycles.
-    cpu.run(40).unwrap();
+    // Runs the program for 80 cycles.
+    cpu.clone()
+        .into_iter()
+        .map(Into::<Vec<Vec<Microcode>>>::into)
+        .flatten()
+        .take(80)
+        .flatten()
+        .for_each(drop)
 }


### PR DESCRIPTION
# Introduction
This PR fixes the duplicate printing of values in the custom_peripheral example stemming from I/O occurring on the render run and execution run. This solves it by running only a state generation pass in the example.

# Linked Issues
resolves #216 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
