### PR TITLE
Implement 12bit unsigned address

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
 	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"lldb.executable": "/usr/bin/lldb",
 		// VS Code don't watch files under ./target
 		"files.watcherExclude": {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -37,5 +37,5 @@ fn main() {
     // is unwrapped to return a CPU snapshot at its current state.
     let state = cpu.run(1_000_000).unwrap();
 
-    println!("{:?}", state);
+    println!("{:#?}", state);
 }

--- a/examples/microcode_step_capture.rs
+++ b/examples/microcode_step_capture.rs
@@ -52,7 +52,7 @@ fn main() {
         .collect();
 
     println!(
-        "{:?}",
+        "{:#?}",
         // Microcode can then be folded onto a cpu to replay its state onto a fresh cpu.
         states.iter().fold(cpu.clone(), |c, mc| mc.execute(c))
     );

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -7,6 +7,7 @@ mod memory;
 mod microcode;
 mod operations;
 mod register;
+mod u12;
 
 /// Represents the address the program counter is set to on chip reset.
 const RESET_PC_VECTOR: u16 = 0x200;

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -27,7 +27,7 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
-            self.addr().wrapping_sub(2),
+            u16::from(self.addr()).wrapping_sub(2),
         ))]
     }
 }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cpu::chip8::u12::u12;
 use crate::cpu::chip8::Chip8;
 
 #[test]
@@ -9,7 +10,7 @@ fn should_generate_jump_with_pc_incrementer() {
             register::WordRegisters::ProgramCounter,
             0x1fe
         ))],
-        opcodes::Jp::new(0x200u16).generate(&cpu)
+        opcodes::Jp::new(u12::new(0x200)).generate(&cpu)
     );
 
     assert_eq!(
@@ -23,6 +24,6 @@ fn should_generate_jump_with_pc_incrementer() {
                 2
             ))
         ],
-        opcodes::OpcodeVariant::from(opcodes::Jp::new(0x200u16)).generate(&cpu)
+        opcodes::OpcodeVariant::from(opcodes::Jp::new(u12::new(0x200))).generate(&cpu)
     )
 }

--- a/src/cpu/chip8/u12.rs
+++ b/src/cpu/chip8/u12.rs
@@ -1,5 +1,5 @@
 /// Represents an unsigned 12-bit integer.
-#[derive(Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 #[allow(non_camel_case_types)]
 pub struct u12(u16);
 

--- a/src/cpu/chip8/u12.rs
+++ b/src/cpu/chip8/u12.rs
@@ -1,0 +1,180 @@
+/// Represents an unsigned 12-bit integer.
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub struct u12(u16);
+
+impl u12 {
+    /// The largest value of the u12 integer.
+    pub const MAX: Self = Self(0xFFF);
+    /// The smallest value of the u12 integer.
+    pub const MIN: Self = Self(0x000);
+    /// The number of bits in the u12 integer.
+    pub const BITS: u32 = 12;
+}
+
+impl u12 {
+    /// Instantiates a new u12.
+    pub fn new(value: u16) -> Self {
+        if value > Self::MAX.0 {
+            panic!("this value will overflow")
+        } else {
+            Self(value)
+        }
+    }
+}
+
+impl core::fmt::Debug for u12 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+        <u16 as core::fmt::Debug>::fmt(&self.0, f)
+    }
+}
+
+impl core::fmt::Display for u12 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+        <u16 as core::fmt::Display>::fmt(&self.0, f)
+    }
+}
+
+impl core::fmt::UpperHex for u12 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> core::fmt::Result {
+        <u16 as core::fmt::UpperHex>::fmt(&self.0, f)
+    }
+}
+
+impl core::fmt::LowerHex for u12 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        <u16 as core::fmt::LowerHex>::fmt(&self.0, f)
+    }
+}
+
+impl core::fmt::Octal for u12 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        <u16 as core::fmt::Octal>::fmt(&self.0, f)
+    }
+}
+
+impl core::fmt::Binary for u12 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        <u16 as core::fmt::Binary>::fmt(&self.0, f)
+    }
+}
+
+impl core::cmp::PartialEq for u12 {
+    fn eq(&self, other: &Self) -> bool {
+        mask(*self).0 == mask(*other).0
+    }
+}
+
+impl Eq for u12 {}
+
+impl core::cmp::PartialOrd for u12 {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        mask(*self).0.partial_cmp(&mask(*other).0)
+    }
+}
+
+impl core::cmp::Ord for u12 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        mask(*self).0.cmp(&mask(*other).0)
+    }
+}
+
+impl core::ops::Add for u12 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        let (lhs, rhs) = (self.0, other.0);
+        let sum = lhs + rhs;
+
+        if sum > Self::MAX.0 {
+            panic!("this arithmetic operation will overflow")
+        } else {
+            Self::new(sum)
+        }
+    }
+}
+
+impl core::ops::Sub for u12 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        let (lhs, rhs) = (self.0, other.0);
+        mask(Self(lhs - rhs))
+    }
+}
+
+impl core::ops::BitAnd for u12 {
+    type Output = Self;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        let (lhs, rhs) = (self.0, other.0);
+        mask(Self(lhs & rhs))
+    }
+}
+
+impl core::ops::BitOr for u12 {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self::Output {
+        let (lhs, rhs) = (self.0, other.0);
+        mask(Self(lhs | rhs))
+    }
+}
+
+impl core::ops::Shl for u12 {
+    type Output = Self;
+
+    fn shl(self, other: Self) -> Self {
+        let (lhs, rhs) = (self.0, other.0);
+        mask(Self(lhs << rhs))
+    }
+}
+
+impl core::ops::Shr for u12 {
+    type Output = Self;
+
+    fn shr(self, other: Self) -> Self {
+        let (lhs, rhs) = (self.0, other.0);
+        mask(Self(lhs >> rhs))
+    }
+}
+
+macro_rules! impl_from_u12_for_uX {
+    ($($t:ty,)*) => {
+        $(
+            impl From<u12> for $t {
+                fn from(src: u12) -> Self {
+                    src.0 as Self
+                }
+            }
+        )*
+    };
+}
+
+impl_from_u12_for_uX!(u16, u32, u64, u128,);
+
+fn mask(value: u12) -> u12 {
+    u12::new(value.0 & u12::MAX.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_add_as_expected() {
+        assert_eq!(u12::new(12), u12::new(5) + u12::new(7))
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused_must_use)]
+    fn should_panic_on_overflowing_add() {
+        u12::new(0xFFFF) + u12::new(1);
+    }
+
+    #[test]
+    fn should_subtract_as_expected() {
+        assert_eq!(u12::new(2), u12::new(7) - u12::new(5))
+    }
+}


### PR DESCRIPTION
# Introduction
This PR implements a 12bit unsigned address type for working with the 12bit addressing in the CHIP-8's addressable memory.

This, for now handles basic arithmetic operations and is by no means comprehensive when compared to the intrinsic `u*` types.

# Linked Issues
resolves #263 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
