### PR TITLE
Cleanup CHIP-8 Opcode layout to leverage shared addressing mode parsers

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -157,7 +157,7 @@ impl Iterator for Chip8IntoIterator {
         ];
 
         // Parse correct operation
-        let ops = match operations::opcodes::OpcodeVariantParser.parse(&opcodes[..]) {
+        let ops = match operations::OpcodeVariantParser.parse(&opcodes[..]) {
             Ok(parcel::MatchStatus::Match {
                 span: _,
                 remainder: _,

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -22,22 +22,7 @@ pub struct Chip8 {
     pc: register::ProgramCounter,
     sp: register::StackPointer,
     i: register::GeneralPurpose<u16>,
-    v0: register::GeneralPurpose<u8>,
-    v1: register::GeneralPurpose<u8>,
-    v2: register::GeneralPurpose<u8>,
-    v3: register::GeneralPurpose<u8>,
-    v4: register::GeneralPurpose<u8>,
-    v5: register::GeneralPurpose<u8>,
-    v6: register::GeneralPurpose<u8>,
-    v7: register::GeneralPurpose<u8>,
-    v8: register::GeneralPurpose<u8>,
-    v9: register::GeneralPurpose<u8>,
-    va: register::GeneralPurpose<u8>,
-    vb: register::GeneralPurpose<u8>,
-    vc: register::GeneralPurpose<u8>,
-    vd: register::GeneralPurpose<u8>,
-    ve: register::GeneralPurpose<u8>,
-    vf: register::GeneralPurpose<u8>,
+    gp_registers: [register::GeneralPurpose<u8>; 0xf],
 }
 
 impl Chip8 {
@@ -73,48 +58,20 @@ impl Chip8 {
         reg_type: register::GpRegisters,
         reg: register::GeneralPurpose<u8>,
     ) -> Self {
-        match reg_type {
-            register::GpRegisters::V0 => self.v0 = reg,
-            register::GpRegisters::V1 => self.v1 = reg,
-            register::GpRegisters::V2 => self.v2 = reg,
-            register::GpRegisters::V3 => self.v3 = reg,
-            register::GpRegisters::V4 => self.v4 = reg,
-            register::GpRegisters::V5 => self.v5 = reg,
-            register::GpRegisters::V6 => self.v6 = reg,
-            register::GpRegisters::V7 => self.v7 = reg,
-            register::GpRegisters::V8 => self.v8 = reg,
-            register::GpRegisters::V9 => self.v9 = reg,
-            register::GpRegisters::Va => self.va = reg,
-            register::GpRegisters::Vb => self.vb = reg,
-            register::GpRegisters::Vc => self.vc = reg,
-            register::GpRegisters::Vd => self.vd = reg,
-            register::GpRegisters::Ve => self.ve = reg,
-            register::GpRegisters::Vf => self.vf = reg,
-        };
+        self.gp_registers
+            .get_mut(reg_type as usize)
+            .map(|cpu_reg| *cpu_reg = reg);
         self
     }
 
     /// Provides a convenient method for unwrapping a GpRegister enum to a
     /// corresponding read of it's namesake register.
     pub fn read_gp_register(&self, reg: register::GpRegisters) -> u8 {
-        match reg {
-            register::GpRegisters::V0 => self.v0.read(),
-            register::GpRegisters::V1 => self.v1.read(),
-            register::GpRegisters::V2 => self.v2.read(),
-            register::GpRegisters::V3 => self.v3.read(),
-            register::GpRegisters::V4 => self.v4.read(),
-            register::GpRegisters::V5 => self.v5.read(),
-            register::GpRegisters::V6 => self.v6.read(),
-            register::GpRegisters::V7 => self.v7.read(),
-            register::GpRegisters::V8 => self.v8.read(),
-            register::GpRegisters::V9 => self.v9.read(),
-            register::GpRegisters::Va => self.va.read(),
-            register::GpRegisters::Vb => self.vb.read(),
-            register::GpRegisters::Vc => self.vc.read(),
-            register::GpRegisters::Vd => self.vd.read(),
-            register::GpRegisters::Ve => self.ve.read(),
-            register::GpRegisters::Vf => self.vf.read(),
-        }
+        self.gp_registers
+            .get(reg as usize)
+            .map(|cpu_reg| cpu_reg.read())
+            // Should never fail due to bounded array.
+            .unwrap()
     }
 
     /// Resets a cpu to a clean state.
@@ -142,22 +99,7 @@ impl Default for Chip8 {
             pc: register::ProgramCounter::with_value(RESET_PC_VECTOR),
             sp: register::StackPointer::default(),
             i: register::GeneralPurpose::default(),
-            v0: register::GeneralPurpose::default(),
-            v1: register::GeneralPurpose::default(),
-            v2: register::GeneralPurpose::default(),
-            v3: register::GeneralPurpose::default(),
-            v4: register::GeneralPurpose::default(),
-            v5: register::GeneralPurpose::default(),
-            v6: register::GeneralPurpose::default(),
-            v7: register::GeneralPurpose::default(),
-            v8: register::GeneralPurpose::default(),
-            v9: register::GeneralPurpose::default(),
-            va: register::GeneralPurpose::default(),
-            vb: register::GeneralPurpose::default(),
-            vc: register::GeneralPurpose::default(),
-            vd: register::GeneralPurpose::default(),
-            ve: register::GeneralPurpose::default(),
-            vf: register::GeneralPurpose::default(),
+            gp_registers: [register::GeneralPurpose::default(); 0xf],
         }
     }
 }
@@ -364,6 +306,6 @@ mod tests {
         cpu.address_space.write(0x201, 0xfa).unwrap();
 
         let state = cpu.run(1).unwrap();
-        assert_eq!(0xff, state.v0.read())
+        assert_eq!(0xff, state.read_gp_register(register::GpRegisters::V0))
     }
 }

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -58,9 +58,7 @@ impl Chip8 {
         reg_type: register::GpRegisters,
         reg: register::GeneralPurpose<u8>,
     ) -> Self {
-        self.gp_registers
-            .get_mut(reg_type as usize)
-            .map(|cpu_reg| *cpu_reg = reg);
+        self.gp_registers[reg_type as usize] = reg;
         self
     }
 

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -94,6 +94,29 @@ impl Chip8 {
         self
     }
 
+    /// Provides a convenient method for unwrapping a GpRegister enum to a
+    /// corresponding read of it's namesake register.
+    pub fn read_gp_register(&self, reg: register::GpRegisters) -> u8 {
+        match reg {
+            register::GpRegisters::V0 => self.v0.read(),
+            register::GpRegisters::V1 => self.v1.read(),
+            register::GpRegisters::V2 => self.v2.read(),
+            register::GpRegisters::V3 => self.v3.read(),
+            register::GpRegisters::V4 => self.v4.read(),
+            register::GpRegisters::V5 => self.v5.read(),
+            register::GpRegisters::V6 => self.v6.read(),
+            register::GpRegisters::V7 => self.v7.read(),
+            register::GpRegisters::V8 => self.v8.read(),
+            register::GpRegisters::V9 => self.v9.read(),
+            register::GpRegisters::Va => self.va.read(),
+            register::GpRegisters::Vb => self.vb.read(),
+            register::GpRegisters::Vc => self.vc.read(),
+            register::GpRegisters::Vd => self.vd.read(),
+            register::GpRegisters::Ve => self.ve.read(),
+            register::GpRegisters::Vf => self.vf.read(),
+        }
+    }
+
     /// Resets a cpu to a clean state.
     pub fn reset() -> Self {
         Self::default()

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -37,8 +37,8 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Absolute> for Absolute {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Immediate {
-    register: register::GpRegisters,
-    value: u8,
+    pub register: register::GpRegisters,
+    pub value: u8,
 }
 
 impl AddressingMode for Immediate {}
@@ -80,5 +80,14 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Immediate> for Immediate {
             })
             .map(|(register, value)| Immediate::new(register, value))
             .parse(input)
+    }
+}
+
+impl Default for Immediate {
+    fn default() -> Self {
+        Self {
+            register: register::GpRegisters::V0,
+            value: 0,
+        }
     }
 }

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -1,0 +1,84 @@
+use crate::cpu::chip8::{operations::ToNibbleBytes, register, u12::u12};
+
+pub trait AddressingMode {}
+
+/// Implied represents a type that explicitly implies it's addressing mode through a 2-byte mnemonic code.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Implied;
+
+impl AddressingMode for Implied {}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Implied> for Implied {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Implied> {
+        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
+            .map(|_| Implied)
+            .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Absolute(u12);
+
+impl AddressingMode for Absolute {}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Absolute> for Absolute {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Absolute> {
+        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
+            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
+            .map(|[[_, first], [second, third]]| {
+                let upper = 0x0f & first;
+                let lower = (second << 4) | third;
+                u12::new(u16::from_be_bytes([upper, lower]))
+            })
+            .map(Absolute)
+            .parse(input)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Immediate {
+    register: register::GpRegisters,
+    value: u8,
+}
+
+impl AddressingMode for Immediate {}
+
+impl Immediate {
+    pub fn new(register: register::GpRegisters, value: u8) -> Self {
+        Self { register, value }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Immediate> for Immediate {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Immediate> {
+        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
+            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
+            .map(|[[_, first], [second, third]]| {
+                let upper = 0x0f & first;
+                let lower = (second << 4) | third;
+                let reg = match upper {
+                    0x0 => register::GpRegisters::V0,
+                    0x1 => register::GpRegisters::V1,
+                    0x2 => register::GpRegisters::V2,
+                    0x3 => register::GpRegisters::V3,
+                    0x4 => register::GpRegisters::V4,
+                    0x5 => register::GpRegisters::V5,
+                    0x6 => register::GpRegisters::V6,
+                    0x7 => register::GpRegisters::V7,
+                    0x8 => register::GpRegisters::V8,
+                    0x9 => register::GpRegisters::V9,
+                    0xa => register::GpRegisters::Va,
+                    0xb => register::GpRegisters::Vb,
+                    0xc => register::GpRegisters::Vc,
+                    0xd => register::GpRegisters::Vd,
+                    0xe => register::GpRegisters::Ve,
+                    0xf => register::GpRegisters::Vf,
+                    _ => panic!("unreachable nibble should be limited to u4."),
+                };
+
+                (reg, lower)
+            })
+            .map(|(register, value)| Immediate::new(register, value))
+            .parse(input)
+    }
+}

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -3,23 +3,26 @@ use crate::cpu::chip8::{operations::ToNibbleBytes, register, u12::u12};
 pub trait AddressingMode {}
 
 /// Implied represents a type that explicitly implies it's addressing mode through a 2-byte mnemonic code.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct Implied;
 
 impl AddressingMode for Implied {}
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Implied> for Implied {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Implied> {
-        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
-            .map(|_| Implied)
-            .parse(input)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct Absolute(u12);
 
 impl AddressingMode for Absolute {}
+
+impl Absolute {
+    #[allow(dead_code)]
+    pub fn new(addr: u12) -> Self {
+        Self(addr)
+    }
+
+    pub fn addr(&self) -> u12 {
+        self.0
+    }
+}
 
 impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Absolute> for Absolute {
     fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Absolute> {

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -1,6 +1,5 @@
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::{microcode::*, Chip8};
-use crate::cpu::register::Register;
 use crate::cpu::Generate;
 
 pub mod opcodes;
@@ -69,24 +68,8 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp {
 
 impl Generate<Chip8, Vec<Microcode>> for opcodes::AddImmediate {
     fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
-        let cpu_reg_value = match self.register {
-            register::GpRegisters::V0 => cpu.v0.read(),
-            register::GpRegisters::V1 => cpu.v1.read(),
-            register::GpRegisters::V2 => cpu.v2.read(),
-            register::GpRegisters::V3 => cpu.v3.read(),
-            register::GpRegisters::V4 => cpu.v4.read(),
-            register::GpRegisters::V5 => cpu.v5.read(),
-            register::GpRegisters::V6 => cpu.v6.read(),
-            register::GpRegisters::V7 => cpu.v7.read(),
-            register::GpRegisters::V8 => cpu.v8.read(),
-            register::GpRegisters::V9 => cpu.v9.read(),
-            register::GpRegisters::Va => cpu.va.read(),
-            register::GpRegisters::Vb => cpu.vb.read(),
-            register::GpRegisters::Vc => cpu.vc.read(),
-            register::GpRegisters::Vd => cpu.vd.read(),
-            register::GpRegisters::Ve => cpu.ve.read(),
-            register::GpRegisters::Vf => cpu.vf.read(),
-        };
+        let cpu_reg_value = cpu.read_gp_register(self.register);
+
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
             register::ByteRegisters::GpRegisters(self.register),
             cpu_reg_value.wrapping_add(self.value),

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -58,11 +58,11 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::OpcodeVariant {
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp {
+impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp<addressing_mode::Absolute> {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
-            u16::from(self.addr()).wrapping_sub(2),
+            u16::from(self.addressing_mode.addr()).wrapping_sub(2),
         ))]
     }
 }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -1,9 +1,9 @@
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::{microcode::*, Chip8};
 use crate::cpu::Generate;
+use parcel::prelude::v1::*;
 
 pub mod addressing_mode;
-pub mod opcodes;
 
 #[cfg(test)]
 mod tests;
@@ -41,11 +41,54 @@ impl ToNibbleBytes for u8 {
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for opcodes::OpcodeVariant {
+pub fn matches_first_nibble_without_taking_input<'a>(
+    opcode: u8,
+) -> impl Parser<'a, &'a [(usize, u8)], u8> {
+    move |input: &'a [(usize, u8)]| match input.get(0) {
+        Some(&(pos, next)) if ((next & 0xf0) >> 4) == opcode => Ok(MatchStatus::Match {
+            span: pos..pos + 1,
+            remainder: &input[0..],
+            inner: opcode,
+        }),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+/// Represents all valid opcodes for the CHIP-8 architecture.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OpcodeVariant {
+    Cls(Cls),
+    Ret(Ret),
+    Jp(Jp<addressing_mode::Absolute>),
+    Call(Call<addressing_mode::Absolute>),
+    AddImmediate(Add<addressing_mode::Immediate>),
+}
+
+/// Provides a Parser type for the OpcodeVariant enum. Constructing an
+/// OpcodeVariant from a stream of bytes.
+pub struct OpcodeVariantParser;
+
+impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], OpcodeVariant> {
+        parcel::one_of(vec![
+            Cls::default().map(OpcodeVariant::Cls),
+            Ret::default().map(OpcodeVariant::Ret),
+            <Jp<addressing_mode::Absolute>>::default().map(OpcodeVariant::Jp),
+            Call::default().map(OpcodeVariant::Call),
+            <Add<addressing_mode::Immediate>>::default().map(OpcodeVariant::AddImmediate),
+        ])
+        .parse(input)
+    }
+}
+
+impl Generate<Chip8, Vec<Microcode>> for OpcodeVariant {
     fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
         match self {
-            opcodes::OpcodeVariant::Jp(op) => Generate::generate(op, cpu),
-            opcodes::OpcodeVariant::AddImmediate(op) => Generate::generate(op, cpu),
+            OpcodeVariant::Jp(op) => Generate::generate(op, cpu),
+            OpcodeVariant::AddImmediate(op) => Generate::generate(op, cpu),
             // TODO: Empty placeholder representing a NOP
             _ => vec![],
         }
@@ -58,7 +101,80 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::OpcodeVariant {
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp<addressing_mode::Absolute> {
+/// Clear the display.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Cls {
+    addressing_mode: addressing_mode::Implied,
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls> for Cls {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Cls> {
+        parcel::parsers::byte::expect_bytes(&[0x00, 0xe0])
+            .map(|_| Cls::default())
+            .parse(input)
+    }
+}
+
+impl From<Cls> for u16 {
+    fn from(_: Cls) -> Self {
+        0x00e0
+    }
+}
+
+/// Return from a subroutine.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Ret {
+    addressing_mode: addressing_mode::Implied,
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ret> for Ret {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Ret> {
+        parcel::parsers::byte::expect_bytes(&[0x00, 0xee])
+            .map(|_| Ret::default())
+            .parse(input)
+    }
+}
+
+impl From<Ret> for u16 {
+    fn from(_: Ret) -> Self {
+        0x00ee
+    }
+}
+
+/// Jp the associated value to the value of the specified register. Setting
+/// the register to the sum.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct Jp<A> {
+    pub addressing_mode: A,
+}
+
+impl<A> Jp<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute>>
+    for Jp<addressing_mode::Absolute>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<addressing_mode::Absolute>> {
+        matches_first_nibble_without_taking_input(0x1)
+            .and_then(|_| addressing_mode::Absolute::default())
+            .map(Jp::new)
+            .parse(input)
+    }
+}
+
+impl From<Jp<addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Jp<addressing_mode::Absolute>) -> Self {
+        OpcodeVariant::Jp(src)
+    }
+}
+
+impl Generate<Chip8, Vec<Microcode>> for Jp<addressing_mode::Absolute> {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
@@ -67,7 +183,72 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp<addressing_mode::Absolute> 
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for opcodes::Add<addressing_mode::Immediate> {
+/// Call subroutine at nnn.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct Call<A> {
+    pub addressing_mode: A,
+}
+
+impl<A> Call<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Call<addressing_mode::Absolute>>
+    for Call<addressing_mode::Absolute>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Call<addressing_mode::Absolute>> {
+        matches_first_nibble_without_taking_input(0x2)
+            .and_then(|_| addressing_mode::Absolute::default())
+            .map(Call::new)
+            .parse(input)
+    }
+}
+
+impl From<Call<addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Call<addressing_mode::Absolute>) -> Self {
+        OpcodeVariant::Call(src)
+    }
+}
+
+/// Adds the associated value to the value of the specified register. Setting
+/// the register to the sum.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct Add<A> {
+    pub addressing_mode: A,
+}
+
+impl<A> Add<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Add<addressing_mode::Immediate>>
+    for Add<addressing_mode::Immediate>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Add<addressing_mode::Immediate>> {
+        matches_first_nibble_without_taking_input(0x7)
+            .and_then(|_| addressing_mode::Immediate::default())
+            .map(Add::new)
+            .parse(input)
+    }
+}
+
+impl From<Add<addressing_mode::Immediate>> for OpcodeVariant {
+    fn from(src: Add<addressing_mode::Immediate>) -> Self {
+        OpcodeVariant::AddImmediate(src)
+    }
+}
+
+impl Generate<Chip8, Vec<Microcode>> for Add<addressing_mode::Immediate> {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(self.addressing_mode.register),

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -2,6 +2,7 @@ use crate::cpu::chip8::register;
 use crate::cpu::chip8::{microcode::*, Chip8};
 use crate::cpu::Generate;
 
+pub mod addressing_mode;
 pub mod opcodes;
 
 #[cfg(test)]
@@ -37,6 +38,21 @@ impl ToNibbleBytes for u8 {
 
     fn to_le_nibbles(&self) -> [u8; 2] {
         [self.to_lower_nibble(), self.to_upper_nibble()]
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Opcode<M, A> {
+    mnemonic: M,
+    addressing_mode: A,
+}
+
+impl<'a, M, A> parcel::Parser<'a, &'a [(usize, u8)], Opcode<M, A>> for Opcode<M, A> {
+    fn parse(
+        &self,
+        _input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Opcode<M, A>> {
+        todo!()
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -67,12 +67,10 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for opcodes::AddImmediate {
-    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
-        let cpu_reg_value = cpu.read_gp_register(self.register);
-
-        vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+    fn generate(self, _: &Chip8) -> Vec<Microcode> {
+        vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(self.register),
-            cpu_reg_value.wrapping_add(self.value),
+            self.value,
         ))]
     }
 }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -41,21 +41,6 @@ impl ToNibbleBytes for u8 {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Opcode<M, A> {
-    mnemonic: M,
-    addressing_mode: A,
-}
-
-impl<'a, M, A> parcel::Parser<'a, &'a [(usize, u8)], Opcode<M, A>> for Opcode<M, A> {
-    fn parse(
-        &self,
-        _input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Opcode<M, A>> {
-        todo!()
-    }
-}
-
 impl Generate<Chip8, Vec<Microcode>> for opcodes::OpcodeVariant {
     fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
         match self {
@@ -82,11 +67,11 @@ impl Generate<Chip8, Vec<Microcode>> for opcodes::Jp {
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for opcodes::AddImmediate {
+impl Generate<Chip8, Vec<Microcode>> for opcodes::Add<addressing_mode::Immediate> {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
-            register::ByteRegisters::GpRegisters(self.register),
-            self.value,
+            register::ByteRegisters::GpRegisters(self.addressing_mode.register),
+            self.addressing_mode.value,
         ))]
     }
 }

--- a/src/cpu/chip8/operations/opcodes.rs
+++ b/src/cpu/chip8/operations/opcodes.rs
@@ -1,14 +1,11 @@
-use crate::cpu::chip8::{
-    operations::{addressing_mode, ToNibbleBytes},
-    u12::u12,
-};
+use crate::cpu::chip8::operations::addressing_mode;
 use parcel::prelude::v1::*;
 
 pub fn matches_first_nibble_without_taking_input<'a>(
     opcode: u8,
 ) -> impl Parser<'a, &'a [(usize, u8)], u8> {
     move |input: &'a [(usize, u8)]| match input.get(0) {
-        Some(&(pos, next)) if (next & 0xf0) == opcode => Ok(MatchStatus::Match {
+        Some(&(pos, next)) if ((next & 0xf0) >> 4) == opcode => Ok(MatchStatus::Match {
             span: pos..pos + 1,
             remainder: &input[0..],
             inner: opcode,
@@ -17,24 +14,13 @@ pub fn matches_first_nibble_without_taking_input<'a>(
     }
 }
 
-fn absolute_addressed_opcode<'a>(opcode: u8) -> impl parcel::Parser<'a, &'a [(usize, u8)], u12> {
-    parcel::take_n(parcel::parsers::byte::any_byte(), 2)
-        .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
-        .predicate(move |[first, _]| first[0] == opcode)
-        .map(|[[_, first], [second, third]]| {
-            let upper = 0x0f & first;
-            let lower = (second << 4) | third;
-            u12::new(u16::from_be_bytes([upper, lower]))
-        })
-}
-
 /// Represents all valid opcodes for the CHIP-8 architecture.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OpcodeVariant {
     Cls(Cls),
     Ret(Ret),
-    Jp(Jp),
-    Call(Call),
+    Jp(Jp<addressing_mode::Absolute>),
+    Call(Call<addressing_mode::Absolute>),
     AddImmediate(Add<addressing_mode::Immediate>),
 }
 
@@ -50,7 +36,7 @@ impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
         parcel::one_of(vec![
             Cls::default().map(OpcodeVariant::Cls),
             Ret::default().map(OpcodeVariant::Ret),
-            Jp::default().map(OpcodeVariant::Jp),
+            <Jp<addressing_mode::Absolute>>::default().map(OpcodeVariant::Jp),
             Call::default().map(OpcodeVariant::Call),
             <Add<addressing_mode::Immediate>>::default().map(OpcodeVariant::AddImmediate),
         ])
@@ -60,12 +46,14 @@ impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
 
 /// Clear the display.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Cls;
+pub struct Cls {
+    addressing_mode: addressing_mode::Implied,
+}
 
 impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls> for Cls {
     fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Cls> {
         parcel::parsers::byte::expect_bytes(&[0x00, 0xe0])
-            .map(|_| Cls)
+            .map(|_| Cls::default())
             .parse(input)
     }
 }
@@ -78,12 +66,14 @@ impl From<Cls> for u16 {
 
 /// Return from a subroutine.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Ret;
+pub struct Ret {
+    addressing_mode: addressing_mode::Implied,
+}
 
 impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ret> for Ret {
     fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Ret> {
         parcel::parsers::byte::expect_bytes(&[0x00, 0xee])
-            .map(|_| Ret)
+            .map(|_| Ret::default())
             .parse(input)
     }
 }
@@ -94,53 +84,71 @@ impl From<Ret> for u16 {
     }
 }
 
-/// Jump to location nnn.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Jp(u12);
+/// Jp the associated value to the value of the specified register. Setting
+/// the register to the sum.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct Jp<A> {
+    pub addressing_mode: A,
+}
 
-impl Jp {
-    pub fn new(addr: u12) -> Self {
-        Self(addr)
-    }
-
-    pub fn addr(&self) -> u12 {
-        self.0
+impl<A> Jp<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp> for Jp {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Jp> {
-        absolute_addressed_opcode(0x01).map(Jp).parse(input)
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute>>
+    for Jp<addressing_mode::Absolute>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<addressing_mode::Absolute>> {
+        matches_first_nibble_without_taking_input(0x1)
+            .and_then(|_| addressing_mode::Absolute::default())
+            .map(Jp::new)
+            .parse(input)
     }
 }
 
-impl From<Jp> for u16 {
-    fn from(src: Jp) -> Self {
-        0x1000 | u16::from(src.0)
-    }
-}
-
-impl From<Jp> for OpcodeVariant {
-    fn from(src: Jp) -> Self {
+impl From<Jp<addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Jp<addressing_mode::Absolute>) -> Self {
         OpcodeVariant::Jp(src)
     }
 }
 
 /// Call subroutine at nnn.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Call(u12);
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct Call<A> {
+    pub addressing_mode: A,
+}
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Call> for Call {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Call> {
-        absolute_addressed_opcode(0x02).map(Call).parse(input)
+impl<A> Call<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
     }
 }
 
-impl From<Call> for u16 {
-    fn from(src: Call) -> Self {
-        0x2000 | u16::from(src.0)
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Call<addressing_mode::Absolute>>
+    for Call<addressing_mode::Absolute>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Call<addressing_mode::Absolute>> {
+        matches_first_nibble_without_taking_input(0x2)
+            .and_then(|_| addressing_mode::Absolute::default())
+            .map(Call::new)
+            .parse(input)
     }
 }
+
+impl From<Call<addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Call<addressing_mode::Absolute>) -> Self {
+        OpcodeVariant::Call(src)
+    }
+}
+
 /// Adds the associated value to the value of the specified register. Setting
 /// the register to the sum.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -161,7 +169,7 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Add<addressing_mode::Immediate>>
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Add<addressing_mode::Immediate>> {
-        matches_first_nibble_without_taking_input(0x70)
+        matches_first_nibble_without_taking_input(0x7)
             .and_then(|_| addressing_mode::Immediate::default())
             .map(Add::new)
             .parse(input)
@@ -177,7 +185,7 @@ impl From<Add<addressing_mode::Immediate>> for OpcodeVariant {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cpu::chip8::register;
+    use crate::cpu::chip8::{register, u12::u12};
 
     #[test]
     fn should_parse_cls_opcode() {
@@ -191,9 +199,9 @@ mod tests {
             Ok(MatchStatus::Match {
                 span: 0..2,
                 remainder: &input[2..],
-                inner: Cls
+                inner: Cls::default()
             }),
-            Cls.parse(&input[..])
+            Cls::default().parse(&input[..])
         );
     }
 
@@ -209,7 +217,7 @@ mod tests {
             Ok(MatchStatus::Match {
                 span: 0..2,
                 remainder: &input[2..],
-                inner: Ret
+                inner: Ret::default()
             }),
             Ret::default().parse(&input[..])
         );
@@ -227,7 +235,7 @@ mod tests {
             Ok(MatchStatus::Match {
                 span: 0..2,
                 remainder: &input[2..],
-                inner: Jp(u12::new(0x0fff))
+                inner: Jp::new(addressing_mode::Absolute::new(u12::new(0xfff)))
             }),
             Jp::default().parse(&input[..])
         );
@@ -245,7 +253,7 @@ mod tests {
             Ok(MatchStatus::Match {
                 span: 0..2,
                 remainder: &input[2..],
-                inner: Call(u12::new(0x0fff))
+                inner: Call::new(addressing_mode::Absolute::new(u12::new(0xfff)))
             }),
             Call::default().parse(&input[..])
         );

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::cpu::chip8::register;
 use crate::cpu::chip8::u12::u12;
 use crate::cpu::chip8::Chip8;
 
@@ -10,7 +11,7 @@ fn should_generate_jump_with_pc_incrementer() {
             register::WordRegisters::ProgramCounter,
             0x1fe
         ))],
-        opcodes::Jp::new(addressing_mode::Absolute::new(u12::new(0x200))).generate(&cpu)
+        Jp::new(addressing_mode::Absolute::new(u12::new(0x200))).generate(&cpu)
     );
 
     assert_eq!(
@@ -24,10 +25,8 @@ fn should_generate_jump_with_pc_incrementer() {
                 2
             ))
         ],
-        opcodes::OpcodeVariant::from(opcodes::Jp::new(addressing_mode::Absolute::new(u12::new(
-            0x200
-        ))))
-        .generate(&cpu)
+        OpcodeVariant::from(Jp::new(addressing_mode::Absolute::new(u12::new(0x200))))
+            .generate(&cpu)
     )
 }
 
@@ -39,7 +38,7 @@ fn should_generate_add_immediate() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
             0xff
         ))],
-        opcodes::Add::new(addressing_mode::Immediate::new(
+        Add::new(addressing_mode::Immediate::new(
             register::GpRegisters::V5,
             0xff
         ))
@@ -57,10 +56,103 @@ fn should_generate_add_immediate() {
                 2
             ))
         ],
-        opcodes::OpcodeVariant::from(opcodes::Add::new(addressing_mode::Immediate::new(
+        OpcodeVariant::from(Add::new(addressing_mode::Immediate::new(
             register::GpRegisters::V5,
             0xff
         )))
         .generate(&cpu)
     )
+}
+
+#[test]
+fn should_parse_cls_opcode() {
+    let input: Vec<(usize, u8)> = 0x00e0u16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Cls::default()
+        }),
+        Cls::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_parse_ret_opcode() {
+    let input: Vec<(usize, u8)> = 0x00eeu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Ret::default()
+        }),
+        Ret::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_parse_jump_opcode() {
+    let input: Vec<(usize, u8)> = 0x1fffu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Jp::new(addressing_mode::Absolute::new(u12::new(0xfff)))
+        }),
+        Jp::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_parse_call_opcode() {
+    let input: Vec<(usize, u8)> = 0x2fffu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Call::new(addressing_mode::Absolute::new(u12::new(0xfff)))
+        }),
+        Call::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_parse_add_immediate_opcode() {
+    let input: Vec<(usize, u8)> = 0x70ffu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Add::new(addressing_mode::Immediate::new(
+                register::GpRegisters::V0,
+                0xff
+            ))
+        }),
+        <Add<addressing_mode::Immediate>>::default().parse(&input[..])
+    );
 }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -32,7 +32,7 @@ fn should_generate_jump_with_pc_incrementer() {
 fn should_generate_add_immediate() {
     let cpu = Chip8::default();
     assert_eq!(
-        vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+        vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
             0xff
         ))],
@@ -41,7 +41,7 @@ fn should_generate_add_immediate() {
 
     assert_eq!(
         vec![
-            Microcode::Write8bitRegister(Write8bitRegister::new(
+            Microcode::Inc8bitRegister(Inc8bitRegister::new(
                 register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
                 0xff
             )),

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -36,7 +36,11 @@ fn should_generate_add_immediate() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
             0xff
         ))],
-        opcodes::AddImmediate::new(register::GpRegisters::V5, 0xff).generate(&cpu)
+        opcodes::Add::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V5,
+            0xff
+        ))
+        .generate(&cpu)
     );
 
     assert_eq!(
@@ -50,7 +54,10 @@ fn should_generate_add_immediate() {
                 2
             ))
         ],
-        opcodes::OpcodeVariant::from(opcodes::AddImmediate::new(register::GpRegisters::V5, 0xff))
-            .generate(&cpu)
+        opcodes::OpcodeVariant::from(opcodes::Add::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V5,
+            0xff
+        )))
+        .generate(&cpu)
     )
 }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -10,7 +10,7 @@ fn should_generate_jump_with_pc_incrementer() {
             register::WordRegisters::ProgramCounter,
             0x1fe
         ))],
-        opcodes::Jp::new(u12::new(0x200)).generate(&cpu)
+        opcodes::Jp::new(addressing_mode::Absolute::new(u12::new(0x200))).generate(&cpu)
     );
 
     assert_eq!(
@@ -24,7 +24,10 @@ fn should_generate_jump_with_pc_incrementer() {
                 2
             ))
         ],
-        opcodes::OpcodeVariant::from(opcodes::Jp::new(u12::new(0x200))).generate(&cpu)
+        opcodes::OpcodeVariant::from(opcodes::Jp::new(addressing_mode::Absolute::new(u12::new(
+            0x200
+        ))))
+        .generate(&cpu)
     )
 }
 

--- a/src/cpu/chip8/register.rs
+++ b/src/cpu/chip8/register.rs
@@ -13,6 +13,7 @@ pub enum WordRegisters {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(usize)]
 pub enum GpRegisters {
     V0,
     V1,


### PR DESCRIPTION
# Introduction
This PR does a few refactors to allow opcodes to take an addressing_mode type that signifies how an opcode should be parsed. This will allow some shared behavior and tests to occur between opcodes.

This also removes the opcode submodule in favor of group each opcodes, parser, type conversions and bytecode generation implementations together.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
