### PR TITLE
Feature/258/add register to i

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -274,11 +274,15 @@ impl crate::cpu::Execute<Chip8> for microcode::Inc16bitRegister {
         match self.register {
             register::WordRegisters::I => {
                 let i = cpu.i.read();
-                cpu.with_i_register(register::GeneralPurpose::with_value(i + self.value))
+                cpu.with_i_register(register::GeneralPurpose::with_value(
+                    i.wrapping_add(self.value),
+                ))
             }
             register::WordRegisters::ProgramCounter => {
                 let pc = cpu.pc.read();
-                cpu.with_pc_register(register::ProgramCounter::with_value(pc + self.value))
+                cpu.with_pc_register(register::ProgramCounter::with_value(
+                    pc.wrapping_add(self.value),
+                ))
             }
         }
     }

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -94,3 +94,60 @@ impl Default for Immediate {
         }
     }
 }
+
+/// Represents an operation on the I register indexed by a General-Purpose
+/// register.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IRegisterIndexed {
+    pub register: register::GpRegisters,
+}
+
+impl AddressingMode for IRegisterIndexed {}
+
+impl IRegisterIndexed {
+    pub fn new(register: register::GpRegisters) -> Self {
+        Self { register }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], IRegisterIndexed> for IRegisterIndexed {
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], IRegisterIndexed> {
+        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
+            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
+            .map(|[[_, first], _]| {
+                let upper = 0x0f & first;
+                match upper {
+                    0x0 => register::GpRegisters::V0,
+                    0x1 => register::GpRegisters::V1,
+                    0x2 => register::GpRegisters::V2,
+                    0x3 => register::GpRegisters::V3,
+                    0x4 => register::GpRegisters::V4,
+                    0x5 => register::GpRegisters::V5,
+                    0x6 => register::GpRegisters::V6,
+                    0x7 => register::GpRegisters::V7,
+                    0x8 => register::GpRegisters::V8,
+                    0x9 => register::GpRegisters::V9,
+                    0xa => register::GpRegisters::Va,
+                    0xb => register::GpRegisters::Vb,
+                    0xc => register::GpRegisters::Vc,
+                    0xd => register::GpRegisters::Vd,
+                    0xe => register::GpRegisters::Ve,
+                    0xf => register::GpRegisters::Vf,
+                    _ => panic!("unreachable nibble should be limited to u4."),
+                }
+            })
+            .map(|register| IRegisterIndexed::new(register))
+            .parse(input)
+    }
+}
+
+impl Default for IRegisterIndexed {
+    fn default() -> Self {
+        Self {
+            register: register::GpRegisters::V0,
+        }
+    }
+}

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -139,7 +139,7 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], IRegisterIndexed> for IRegisterIn
                     _ => panic!("unreachable nibble should be limited to u4."),
                 }
             })
-            .map(|register| IRegisterIndexed::new(register))
+            .map(IRegisterIndexed::new)
             .parse(input)
     }
 }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -2,67 +2,7 @@ use super::*;
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::u12::u12;
 use crate::cpu::chip8::Chip8;
-
-#[test]
-fn should_generate_jump_with_pc_incrementer() {
-    let cpu = Chip8::default();
-    assert_eq!(
-        vec![Microcode::Write16bitRegister(Write16bitRegister::new(
-            register::WordRegisters::ProgramCounter,
-            0x1fe
-        ))],
-        Jp::new(addressing_mode::Absolute::new(u12::new(0x200))).generate(&cpu)
-    );
-
-    assert_eq!(
-        vec![
-            Microcode::Write16bitRegister(Write16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                0x1fe
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Jp::new(addressing_mode::Absolute::new(u12::new(0x200))))
-            .generate(&cpu)
-    )
-}
-
-#[test]
-fn should_generate_add_immediate() {
-    let cpu = Chip8::default();
-    assert_eq!(
-        vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
-            register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
-            0xff
-        ))],
-        Add::new(addressing_mode::Immediate::new(
-            register::GpRegisters::V5,
-            0xff
-        ))
-        .generate(&cpu)
-    );
-
-    assert_eq!(
-        vec![
-            Microcode::Inc8bitRegister(Inc8bitRegister::new(
-                register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
-                0xff
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Add::new(addressing_mode::Immediate::new(
-            register::GpRegisters::V5,
-            0xff
-        )))
-        .generate(&cpu)
-    )
-}
+use crate::cpu::register::Register;
 
 #[test]
 fn should_parse_cls_opcode() {
@@ -119,6 +59,33 @@ fn should_parse_jump_opcode() {
 }
 
 #[test]
+fn should_generate_jump_with_pc_incrementer() {
+    let cpu = Chip8::default();
+    assert_eq!(
+        vec![Microcode::Write16bitRegister(Write16bitRegister::new(
+            register::WordRegisters::ProgramCounter,
+            0x1fe
+        ))],
+        Jp::new(addressing_mode::Absolute::new(u12::new(0x200))).generate(&cpu)
+    );
+
+    assert_eq!(
+        vec![
+            Microcode::Write16bitRegister(Write16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                0x1fe
+            )),
+            Microcode::Inc16bitRegister(Inc16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                2
+            ))
+        ],
+        OpcodeVariant::from(Jp::new(addressing_mode::Absolute::new(u12::new(0x200))))
+            .generate(&cpu)
+    )
+}
+
+#[test]
 fn should_parse_call_opcode() {
     let input: Vec<(usize, u8)> = 0x2fffu16
         .to_be_bytes()
@@ -155,4 +122,90 @@ fn should_parse_add_immediate_opcode() {
         }),
         <Add<addressing_mode::Immediate>>::default().parse(&input[..])
     );
+}
+
+#[test]
+fn should_generate_add_immediate() {
+    let cpu = Chip8::default();
+    assert_eq!(
+        vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
+            register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
+            0xff
+        ))],
+        Add::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V5,
+            0xff
+        ))
+        .generate(&cpu)
+    );
+
+    assert_eq!(
+        vec![
+            Microcode::Inc8bitRegister(Inc8bitRegister::new(
+                register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
+                0xff
+            )),
+            Microcode::Inc16bitRegister(Inc16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                2
+            ))
+        ],
+        OpcodeVariant::from(Add::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V5,
+            0xff
+        )))
+        .generate(&cpu)
+    )
+}
+
+#[test]
+fn should_parse_add_i_register_indexed_opcode() {
+    let input: Vec<(usize, u8)> = 0xf01eu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Add::new(addressing_mode::IRegisterIndexed::new(
+                register::GpRegisters::V0
+            ))
+        }),
+        <Add<addressing_mode::IRegisterIndexed>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_add_i_register_indexed() {
+    let cpu = Chip8::default().with_gp_register(
+        register::GpRegisters::V5,
+        register::GeneralPurpose::<u8>::with_value(0xff),
+    );
+    assert_eq!(
+        vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+            register::WordRegisters::I,
+            0xff
+        ))],
+        Add::new(addressing_mode::IRegisterIndexed::new(
+            register::GpRegisters::V5
+        ))
+        .generate(&cpu)
+    );
+
+    assert_eq!(
+        vec![
+            Microcode::Inc16bitRegister(Inc16bitRegister::new(register::WordRegisters::I, 0xff)),
+            Microcode::Inc16bitRegister(Inc16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                2
+            ))
+        ],
+        OpcodeVariant::from(Add::new(addressing_mode::IRegisterIndexed::new(
+            register::GpRegisters::V5,
+        )))
+        .generate(&cpu)
+    )
 }


### PR DESCRIPTION
# Introduction
This PR implements the `ADD I, Vx` opcode for the CHIP-8 emulator.

# Linked Issues
resolves #258 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
