### PR TITLE
Implement `And Vx, Vy` opcode

### DIFF
--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -59,25 +59,8 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Immediate> for Immediate {
             .map(|[[_, first], [second, third]]| {
                 let upper = 0x0f & first;
                 let lower = (second << 4) | third;
-                let reg = match upper {
-                    0x0 => register::GpRegisters::V0,
-                    0x1 => register::GpRegisters::V1,
-                    0x2 => register::GpRegisters::V2,
-                    0x3 => register::GpRegisters::V3,
-                    0x4 => register::GpRegisters::V4,
-                    0x5 => register::GpRegisters::V5,
-                    0x6 => register::GpRegisters::V6,
-                    0x7 => register::GpRegisters::V7,
-                    0x8 => register::GpRegisters::V8,
-                    0x9 => register::GpRegisters::V9,
-                    0xa => register::GpRegisters::Va,
-                    0xb => register::GpRegisters::Vb,
-                    0xc => register::GpRegisters::Vc,
-                    0xd => register::GpRegisters::Vd,
-                    0xe => register::GpRegisters::Ve,
-                    0xf => register::GpRegisters::Vf,
-                    _ => panic!("unreachable nibble should be limited to u4."),
-                };
+                let reg = std::convert::TryFrom::<u8>::try_from(upper)
+                    .expect("unreachable nibble should be limited to u4.");
 
                 (reg, lower)
             })
@@ -119,25 +102,8 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], IRegisterIndexed> for IRegisterIn
             .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
             .map(|[[_, first], _]| {
                 let upper = 0x0f & first;
-                match upper {
-                    0x0 => register::GpRegisters::V0,
-                    0x1 => register::GpRegisters::V1,
-                    0x2 => register::GpRegisters::V2,
-                    0x3 => register::GpRegisters::V3,
-                    0x4 => register::GpRegisters::V4,
-                    0x5 => register::GpRegisters::V5,
-                    0x6 => register::GpRegisters::V6,
-                    0x7 => register::GpRegisters::V7,
-                    0x8 => register::GpRegisters::V8,
-                    0x9 => register::GpRegisters::V9,
-                    0xa => register::GpRegisters::Va,
-                    0xb => register::GpRegisters::Vb,
-                    0xc => register::GpRegisters::Vc,
-                    0xd => register::GpRegisters::Vd,
-                    0xe => register::GpRegisters::Ve,
-                    0xf => register::GpRegisters::Vf,
-                    _ => panic!("unreachable nibble should be limited to u4."),
-                }
+                std::convert::TryFrom::<u8>::try_from(upper)
+                    .expect("unreachable nibble should be limited to u4.")
             })
             .map(IRegisterIndexed::new)
             .parse(input)

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -63,6 +63,7 @@ pub enum OpcodeVariant {
     Call(Call<addressing_mode::Absolute>),
     AddImmediate(Add<addressing_mode::Immediate>),
     AddIRegisterIndexed(Add<addressing_mode::IRegisterIndexed>),
+    AndByteRegisterOperation(And<addressing_mode::ByteRegisterOperation>),
 }
 
 /// Provides a Parser type for the OpcodeVariant enum. Constructing an
@@ -82,6 +83,8 @@ impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
             <Add<addressing_mode::Immediate>>::default().map(OpcodeVariant::AddImmediate),
             <Add<addressing_mode::IRegisterIndexed>>::default()
                 .map(OpcodeVariant::AddIRegisterIndexed),
+            <And<addressing_mode::ByteRegisterOperation>>::default()
+                .map(OpcodeVariant::AndByteRegisterOperation),
         ])
         .parse(input)
     }
@@ -93,6 +96,7 @@ impl Generate<Chip8, Vec<Microcode>> for OpcodeVariant {
             OpcodeVariant::Jp(op) => Generate::generate(op, cpu),
             OpcodeVariant::AddImmediate(op) => Generate::generate(op, cpu),
             OpcodeVariant::AddIRegisterIndexed(op) => Generate::generate(op, cpu),
+            OpcodeVariant::AndByteRegisterOperation(op) => Generate::generate(op, cpu),
             // TODO: Empty placeholder representing a NOP
             _ => vec![],
         }
@@ -292,6 +296,57 @@ impl Generate<Chip8, Vec<Microcode>> for Add<addressing_mode::IRegisterIndexed> 
         vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
             register::WordRegisters::I,
             gp_val as u16,
+        ))]
+    }
+}
+
+/// And represents a binary & operation.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct And<A> {
+    pub addressing_mode: A,
+}
+
+impl<A> And<A> {
+    pub fn new(addressing_mode: A) -> Self {
+        Self { addressing_mode }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], And<addressing_mode::ByteRegisterOperation>>
+    for And<addressing_mode::ByteRegisterOperation>
+{
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], And<addressing_mode::ByteRegisterOperation>> {
+        matches_first_nibble_without_taking_input(0x8)
+            .peek_next(
+                // discard the first byte since the previous parser takes nothing.
+                parcel::parsers::byte::any_byte().and_then(|_| {
+                    parcel::parsers::byte::any_byte().predicate(|&v| (v & 0x0f) == 0x04)
+                }),
+            )
+            .and_then(|_| addressing_mode::ByteRegisterOperation::default())
+            .map(And::new)
+            .parse(input)
+    }
+}
+
+impl From<And<addressing_mode::ByteRegisterOperation>> for OpcodeVariant {
+    fn from(src: And<addressing_mode::ByteRegisterOperation>) -> Self {
+        OpcodeVariant::AndByteRegisterOperation(src)
+    }
+}
+
+impl Generate<Chip8, Vec<Microcode>> for And<addressing_mode::ByteRegisterOperation> {
+    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
+        let src_val = cpu.read_gp_register(self.addressing_mode.src);
+        let dest_val = cpu.read_gp_register(self.addressing_mode.dest);
+        let result = dest_val & src_val;
+
+        vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+            register::ByteRegisters::GpRegisters(self.addressing_mode.dest),
+            result,
         ))]
     }
 }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -323,7 +323,7 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], And<addressing_mode::ByteRegister
             .peek_next(
                 // discard the first byte since the previous parser takes nothing.
                 parcel::parsers::byte::any_byte().and_then(|_| {
-                    parcel::parsers::byte::any_byte().predicate(|&v| (v & 0x0f) == 0x04)
+                    parcel::parsers::byte::any_byte().predicate(|&v| (v & 0x0f) == 0x02)
                 }),
             )
             .and_then(|_| addressing_mode::ByteRegisterOperation::default())

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -212,7 +212,7 @@ fn should_generate_add_i_register_indexed() {
 
 #[test]
 fn should_parse_and_byte_register_operation_opcode() {
-    let input: Vec<(usize, u8)> = 0x8014u16
+    let input: Vec<(usize, u8)> = 0x8012u16
         .to_be_bytes()
         .iter()
         .copied()

--- a/src/cpu/chip8/register.rs
+++ b/src/cpu/chip8/register.rs
@@ -12,6 +12,8 @@ pub enum WordRegisters {
     ProgramCounter,
 }
 
+/// GpRegisters represents each type of general purpose registers,
+/// representable as a usize for indexing purposes.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(usize)]
 pub enum GpRegisters {

--- a/src/cpu/chip8/register.rs
+++ b/src/cpu/chip8/register.rs
@@ -33,6 +33,32 @@ pub enum GpRegisters {
     Vf,
 }
 
+impl std::convert::TryFrom<u8> for GpRegisters {
+    type Error = &'static str;
+
+    fn try_from(src: u8) -> Result<Self, Self::Error> {
+        match src {
+            0x0 => Ok(GpRegisters::V0),
+            0x1 => Ok(GpRegisters::V1),
+            0x2 => Ok(GpRegisters::V2),
+            0x3 => Ok(GpRegisters::V3),
+            0x4 => Ok(GpRegisters::V4),
+            0x5 => Ok(GpRegisters::V5),
+            0x6 => Ok(GpRegisters::V6),
+            0x7 => Ok(GpRegisters::V7),
+            0x8 => Ok(GpRegisters::V8),
+            0x9 => Ok(GpRegisters::V9),
+            0xa => Ok(GpRegisters::Va),
+            0xb => Ok(GpRegisters::Vb),
+            0xc => Ok(GpRegisters::Vc),
+            0xd => Ok(GpRegisters::Vd),
+            0xe => Ok(GpRegisters::Ve),
+            0xf => Ok(GpRegisters::Vf),
+            _ => Err("value is outside the bounds of a u4."),
+        }
+    }
+}
+
 /// Represents the special Timer registers that decrement at a pre-selected
 /// 60hz (1 second), clock-rate.
 #[derive(Debug, PartialEq, Clone, Copy)]


### PR DESCRIPTION
# Introduction
This PR implements that `And Vx, Vy` instruction for the CHIP-8 architecture.

# Linked Issues
resolves #240 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
