### PR TITLE
Implement ExecuteMut trait for mos6502

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -17,8 +17,17 @@ pub trait Generate<T, U> {
     fn generate(self, cpu: &T) -> U;
 }
 
+/// Defines a trait for implementing transformation on a CPU, returning the
+/// modified CPU.
 pub trait Execute<T> {
     fn execute(self, cpu: T) -> T;
+}
+
+/// Defines a trait for implementing transformation on a CPU, modifying a
+/// references to a CPU in place. The difference between Execute and ExecuteMut
+/// is that a ExecuteMut is implemented on the object (cpu) being modified.
+pub trait ExecuteMut<T> {
+    fn execute_mut(&mut self, operation: &T);
 }
 
 pub trait Cpu<T> {


### PR DESCRIPTION
# Introduction
This PR introduces an `ExecuteMut` trait that provides for modifying a cpu directly with an operation as an alternative to the `Execute` trait which consumes a CPU, returning a new instance with the change applied. In addition this updates the CPU IntoIterator trait to use `ExecuteMut` instead of `Execute` for it's `Iterator` implementation to prevent cloning the cpu unnecessarily on each iteration. This change leads to a ~25% performance improvement over a larger set of operations in my tests.

Before:

```
cargo run --release --example basic  2.97s user 0.01s system 99% cpu 2.979 total
```

After:

```
cargo run --release --example basic  2.30s user 0.02s system 99% cpu 2.325 total
```


# Linked Issues
resolves #223 
#271 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
