### PR TITLE
Implement jump V0 offset opcode

### DIFF
--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -60,8 +60,8 @@ pub fn matches_first_nibble_without_taking_input<'a>(
 pub enum OpcodeVariant {
     Cls(Cls),
     Ret(Ret),
-    JpAbsolute(Jp<addressing_mode::Absolute, 0x1>),
-    JpAbsoluteIndexedByV0(Jp<addressing_mode::Absolute, 0xb>),
+    JpAbsolute(Jp<NonV0Indexed, addressing_mode::Absolute>),
+    JpAbsoluteIndexedByV0(Jp<V0Indexed, addressing_mode::Absolute>),
     Call(Call<addressing_mode::Absolute>),
     AddImmediate(Add<addressing_mode::Immediate>),
     AddIRegisterIndexed(Add<addressing_mode::IRegisterIndexed>),
@@ -80,8 +80,8 @@ impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
         parcel::one_of(vec![
             Cls::default().map(OpcodeVariant::Cls),
             Ret::default().map(OpcodeVariant::Ret),
-            <Jp<addressing_mode::Absolute, 0x1>>::default().map(OpcodeVariant::JpAbsolute),
-            <Jp<addressing_mode::Absolute, 0xb>>::default()
+            <Jp<NonV0Indexed, addressing_mode::Absolute>>::default().map(OpcodeVariant::JpAbsolute),
+            <Jp<V0Indexed, addressing_mode::Absolute>>::default()
                 .map(OpcodeVariant::JpAbsoluteIndexedByV0),
             Call::default().map(OpcodeVariant::Call),
             <Add<addressing_mode::Immediate>>::default().map(OpcodeVariant::AddImmediate),
@@ -154,26 +154,38 @@ impl From<Ret> for u16 {
     }
 }
 
+/// Reprents a Jp command that is v0 indexed.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct V0Indexed;
+
+/// Reprents an absolute Jp command that is not v0 indexed.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct NonV0Indexed;
+
 /// Jp the associated value to the value of the specified register. Setting
 /// the register to the sum.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct Jp<A, const O: u8> {
+pub struct Jp<T, A> {
+    r#type: std::marker::PhantomData<T>,
     pub addressing_mode: A,
 }
 
-impl<A, const O: u8> Jp<A, O> {
+impl<T, A> Jp<T, A> {
     pub fn new(addressing_mode: A) -> Self {
-        Self { addressing_mode }
+        Self {
+            r#type: std::marker::PhantomData,
+            addressing_mode,
+        }
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute, 0x1>>
-    for Jp<addressing_mode::Absolute, 0x1>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<NonV0Indexed, addressing_mode::Absolute>>
+    for Jp<NonV0Indexed, addressing_mode::Absolute>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<addressing_mode::Absolute, 0x1>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<NonV0Indexed, addressing_mode::Absolute>> {
         matches_first_nibble_without_taking_input(0x1)
             .and_then(|_| addressing_mode::Absolute::default())
             .map(Jp::new)
@@ -181,13 +193,13 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute, 0x1
     }
 }
 
-impl From<Jp<addressing_mode::Absolute, 0x1>> for OpcodeVariant {
-    fn from(src: Jp<addressing_mode::Absolute, 0x1>) -> Self {
+impl From<Jp<NonV0Indexed, addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Jp<NonV0Indexed, addressing_mode::Absolute>) -> Self {
         OpcodeVariant::JpAbsolute(src)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for Jp<addressing_mode::Absolute, 0x1> {
+impl Generate<Chip8, Vec<Microcode>> for Jp<NonV0Indexed, addressing_mode::Absolute> {
     fn generate(self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
@@ -197,13 +209,13 @@ impl Generate<Chip8, Vec<Microcode>> for Jp<addressing_mode::Absolute, 0x1> {
 }
 
 // Jp Absolute + V0
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute, 0xb>>
-    for Jp<addressing_mode::Absolute, 0xb>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<V0Indexed, addressing_mode::Absolute>>
+    for Jp<V0Indexed, addressing_mode::Absolute>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<addressing_mode::Absolute, 0xb>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<V0Indexed, addressing_mode::Absolute>> {
         matches_first_nibble_without_taking_input(0xb)
             .and_then(|_| addressing_mode::Absolute::default())
             .map(Jp::new)
@@ -211,13 +223,13 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<addressing_mode::Absolute, 0xb
     }
 }
 
-impl From<Jp<addressing_mode::Absolute, 0xb>> for OpcodeVariant {
-    fn from(src: Jp<addressing_mode::Absolute, 0xb>) -> Self {
+impl From<Jp<V0Indexed, addressing_mode::Absolute>> for OpcodeVariant {
+    fn from(src: Jp<V0Indexed, addressing_mode::Absolute>) -> Self {
         OpcodeVariant::JpAbsoluteIndexedByV0(src)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for Jp<addressing_mode::Absolute, 0xb> {
+impl Generate<Chip8, Vec<Microcode>> for Jp<V0Indexed, addressing_mode::Absolute> {
     fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
         let v0_val = cpu.read_gp_register(register::GpRegisters::V0);
         let abs_addr = self.addressing_mode.addr();

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -52,9 +52,9 @@ fn should_parse_jump_absolute_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Jp::<addressing_mode::Absolute, 0x1>::new(addressing_mode::Absolute::new(
-                u12::new(0xfff)
-            ))
+            inner: Jp::<NonV0Indexed, addressing_mode::Absolute>::new(
+                addressing_mode::Absolute::new(u12::new(0xfff))
+            )
         }),
         Jp::default().parse(&input[..])
     );
@@ -68,8 +68,10 @@ fn should_generate_jump_absolute_with_pc_incrementer() {
             register::WordRegisters::ProgramCounter,
             0x1fe
         ))],
-        Jp::<addressing_mode::Absolute, 0x1>::new(addressing_mode::Absolute::new(u12::new(0x200)))
-            .generate(&cpu)
+        Jp::<NonV0Indexed, addressing_mode::Absolute>::new(addressing_mode::Absolute::new(
+            u12::new(0x200)
+        ))
+        .generate(&cpu)
     );
 
     assert_eq!(
@@ -83,7 +85,7 @@ fn should_generate_jump_absolute_with_pc_incrementer() {
                 2
             ))
         ],
-        OpcodeVariant::from(Jp::<addressing_mode::Absolute, 0x1>::new(
+        OpcodeVariant::from(Jp::<NonV0Indexed, addressing_mode::Absolute>::new(
             addressing_mode::Absolute::new(u12::new(0x200))
         ))
         .generate(&cpu)
@@ -102,7 +104,7 @@ fn should_parse_jump_absolute_indexed_by_v0_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Jp::<addressing_mode::Absolute, 0xb>::new(addressing_mode::Absolute::new(
+            inner: Jp::<V0Indexed, addressing_mode::Absolute>::new(addressing_mode::Absolute::new(
                 u12::new(0xfff)
             ))
         }),
@@ -121,8 +123,10 @@ fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
             register::WordRegisters::ProgramCounter,
             0x203
         ))],
-        Jp::<addressing_mode::Absolute, 0xb>::new(addressing_mode::Absolute::new(u12::new(0x200)))
-            .generate(&cpu)
+        Jp::<V0Indexed, addressing_mode::Absolute>::new(addressing_mode::Absolute::new(u12::new(
+            0x200
+        )))
+        .generate(&cpu)
     );
 
     assert_eq!(
@@ -136,7 +140,7 @@ fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
                 2
             ))
         ],
-        OpcodeVariant::from(Jp::<addressing_mode::Absolute, 0xb>::new(
+        OpcodeVariant::from(Jp::<V0Indexed, addressing_mode::Absolute>::new(
             addressing_mode::Absolute::new(u12::new(0x200))
         ))
         .generate(&cpu)


### PR DESCRIPTION
# Introduction
This PR implements the `Jp V0, addr` opcode. In addition, it leverages an additional type parameter for the Jp command that takes one of two types representing if the jump is v0 indexed or not. I'm not sure if I'm happy with this yet and may change the jump to a different opcode, or just implement a different address mode. Due to this being a special case, I'm still up in the air about it. However this implementation seems to be fairly tight and uses the least additional code.

# Linked Issues
resolves #249 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
