### PR TITLE
Finish implementing ExecuteMut for other ISAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,9 @@ A CPU device and emulation framework focused on extensibility and flexibility of
 - [mainspring](#mainspring)
     - [Building](#building)
     - [Included](#included)
-        - [Traits and Types](#traits-and-types)
-            - [Addressable](#addressable)
-            - [CPU](#cpu)
-            - [StepState](#stepstate)
-            - [Register](#register)
-            - [Offset](#offset)
-            - [Cyclable](#cyclable)
         - [Reference Implementations](#reference-implementations)
-            - [Mos6502](#mos6502)
+            - [MOS 6502](#mos-6502)
+            - [CHIP-8](#chip-8)
     - [Warnings](#warnings)
 
 <!-- /TOC -->
@@ -25,28 +19,12 @@ Mainspring is intendended to be included as a library and an [examples](./exampl
 ## Included
 The framework comes with both traits and types to assist users with implementations of additional CPUs/Architectures as well as reference implementations. The framework tries to keep the Traits as generic as possible to prevent as few reference implementations from being imposed on the user as possible.
 
-### Traits and Types
-#### Addressable
-The Addressable trait represents any type that can be registered with a CPUs address map. These can include ReadOnly and ReadWrite memory, Peripheral Devices, IO... etc. and requires only that the device have a defined address space and read/write methods.
-
-#### CPU
-CPU requires only a single method, `run`. This method will attempt to run the cpu for the number of cycles specified as it's argument and return the new state of the CPU.
-
-#### StepState
-A wrapper around the CPU trait that also implements CPU. This type is meant to store additional metadata about a CPUs execution as it moves inbetween cycles. 
-
-#### Register
-Register functions very similarly to Addressable, requiring only that a `read` and `write` method be implemented and functions as a wrapper around a CPU register.
-
-#### Offset
-Contains a single `offset` method that returns a usize count of the byte offset of an operation.
-
-#### Cyclable
-Contains a single method `cycles` which returns a usize count representing the cycles of an operations.
-
 ### Reference Implementations
-#### Mos6502
-The [Mos6502](https://en.wikipedia.org/wiki/MOS_Technology_6502) is the first cpu emulated in this example and is used heavily as the basis for most of the traits and examples. Basic usages and hardware layouts can be found in the [examples](./examples/) directory.
+#### MOS 6502
+The [MOS 6502](https://en.wikipedia.org/wiki/MOS_Technology_6502) is the first cpu emulated in this example and is used heavily as the basis for most of the traits and examples. Basic usages and hardware layouts can be found in the [examples](./examples/) directory.
+
+#### CHIP-8
+[CHIP-8](https://en.wikipedia.org/wiki/CHIP-8).
 
 ## Warnings
 This is a built to support the other projects I've implemented in the First Principles of Computing project and may be subject to API change.

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -288,9 +288,7 @@ impl crate::cpu::Execute<Chip8> for microcode::Dec8bitRegister {
 }
 
 impl crate::cpu::ExecuteMut<microcode::Dec8bitRegister> for Chip8 {
-    fn execute_mut(&mut self, _: &microcode::Dec8bitRegister) {
-        ()
-    }
+    fn execute_mut(&mut self, _: &microcode::Dec8bitRegister) {}
 }
 
 impl crate::cpu::Execute<Chip8> for microcode::Write16bitRegister {
@@ -342,9 +340,7 @@ impl crate::cpu::Execute<Chip8> for microcode::Dec16bitRegister {
 }
 
 impl crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8 {
-    fn execute_mut(&mut self, _: &microcode::Dec16bitRegister) {
-        ()
-    }
+    fn execute_mut(&mut self, _: &microcode::Dec16bitRegister) {}
 }
 
 impl crate::cpu::Execute<Chip8> for microcode::PushStack {
@@ -354,9 +350,7 @@ impl crate::cpu::Execute<Chip8> for microcode::PushStack {
 }
 
 impl crate::cpu::ExecuteMut<microcode::PushStack> for Chip8 {
-    fn execute_mut(&mut self, _: &microcode::PushStack) {
-        ()
-    }
+    fn execute_mut(&mut self, _: &microcode::PushStack) {}
 }
 
 impl crate::cpu::Execute<Chip8> for microcode::PopStack {
@@ -366,9 +360,7 @@ impl crate::cpu::Execute<Chip8> for microcode::PopStack {
 }
 
 impl crate::cpu::ExecuteMut<microcode::PopStack> for Chip8 {
-    fn execute_mut(&mut self, _: &microcode::PopStack) {
-        ()
-    }
+    fn execute_mut(&mut self, _: &microcode::PopStack) {}
 }
 
 #[cfg(test)]

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -1,6 +1,6 @@
 use crate::address_map::{AddressMap, Addressable};
+use crate::cpu::Execute;
 use crate::cpu::{register::Register, Cpu, StepState};
-use crate::cpu::{Execute, Generate};
 use parcel::Parser;
 
 mod memory;
@@ -170,7 +170,14 @@ impl Iterator for Chip8IntoIterator {
         }
         .unwrap();
 
-        let microcode_steps = ops.generate(&self.state);
+        let microcode_steps: Vec<microcode::Microcode> = ops
+            .generate(&self.state)
+            .into_iter()
+            .chain(vec![microcode::Microcode::Inc16bitRegister(
+                // increment the PC by instruction size.
+                microcode::Inc16bitRegister::new(register::WordRegisters::ProgramCounter, 2),
+            )])
+            .collect();
 
         self.state = microcode_steps
             .iter()

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -95,7 +95,7 @@ impl<'a> Parser<'a, &'a [(usize, u8)], OpcodeVariant> for OpcodeVariantParser {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for OpcodeVariant {
-    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
         match self {
             OpcodeVariant::JpAbsolute(op) => Generate::generate(op, cpu),
             OpcodeVariant::JpAbsoluteIndexedByV0(op) => Generate::generate(op, cpu),
@@ -200,7 +200,7 @@ impl From<Jp<NonV0Indexed, addressing_mode::Absolute>> for OpcodeVariant {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for Jp<NonV0Indexed, addressing_mode::Absolute> {
-    fn generate(self, _: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
             u16::from(self.addressing_mode.addr()).wrapping_sub(2),
@@ -230,7 +230,7 @@ impl From<Jp<V0Indexed, addressing_mode::Absolute>> for OpcodeVariant {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for Jp<V0Indexed, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
         let v0_val = cpu.read_gp_register(register::GpRegisters::V0);
         let abs_addr = self.addressing_mode.addr();
         let jmp_addr = abs_addr.wrapping_add(u12::new(v0_val as u16));
@@ -308,7 +308,7 @@ impl From<Add<addressing_mode::Immediate>> for OpcodeVariant {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for Add<addressing_mode::Immediate> {
-    fn generate(self, _: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, _: &Chip8) -> Vec<Microcode> {
         vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(self.addressing_mode.register),
             self.addressing_mode.value,
@@ -342,7 +342,7 @@ impl From<Add<addressing_mode::IRegisterIndexed>> for OpcodeVariant {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for Add<addressing_mode::IRegisterIndexed> {
-    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
         let gp_val = cpu.read_gp_register(self.addressing_mode.register);
         vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
             register::WordRegisters::I,
@@ -390,7 +390,7 @@ impl From<And<addressing_mode::ByteRegisterOperation>> for OpcodeVariant {
 }
 
 impl Generate<Chip8, Vec<Microcode>> for And<addressing_mode::ByteRegisterOperation> {
-    fn generate(self, cpu: &Chip8) -> Vec<Microcode> {
+    fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
         let src_val = cpu.read_gp_register(self.addressing_mode.src);
         let dest_val = cpu.read_gp_register(self.addressing_mode.dest);
         let result = dest_val & src_val;

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -62,6 +62,7 @@ pub struct OpcodeVariantParser;
 impl<'a> Parser<'a, &'a [(usize, u8)], Box<dyn Generate<Chip8, Vec<Microcode>>>>
     for OpcodeVariantParser
 {
+    #[allow(clippy::clippy::type_complexity)]
     fn parse(
         &self,
         input: &'a [(usize, u8)],

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -73,23 +73,6 @@ fn should_generate_jump_absolute_with_pc_incrementer() {
         ))
         .generate(&cpu)
     );
-
-    assert_eq!(
-        vec![
-            Microcode::Write16bitRegister(Write16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                0x1fe
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Jp::<NonV0Indexed, addressing_mode::Absolute>::new(
-            addressing_mode::Absolute::new(u12::new(0x200))
-        ))
-        .generate(&cpu)
-    )
 }
 
 #[test]
@@ -128,23 +111,6 @@ fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
         )))
         .generate(&cpu)
     );
-
-    assert_eq!(
-        vec![
-            Microcode::Write16bitRegister(Write16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                0x203
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Jp::<V0Indexed, addressing_mode::Absolute>::new(
-            addressing_mode::Absolute::new(u12::new(0x200))
-        ))
-        .generate(&cpu)
-    )
 }
 
 #[test]
@@ -200,24 +166,6 @@ fn should_generate_add_immediate() {
         ))
         .generate(&cpu)
     );
-
-    assert_eq!(
-        vec![
-            Microcode::Inc8bitRegister(Inc8bitRegister::new(
-                register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
-                0xff
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Add::new(addressing_mode::Immediate::new(
-            register::GpRegisters::V5,
-            0xff
-        )))
-        .generate(&cpu)
-    )
 }
 
 #[test]
@@ -256,20 +204,6 @@ fn should_generate_add_i_register_indexed() {
         ))
         .generate(&cpu)
     );
-
-    assert_eq!(
-        vec![
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(register::WordRegisters::I, 0xff)),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(Add::new(addressing_mode::IRegisterIndexed::new(
-            register::GpRegisters::V5,
-        )))
-        .generate(&cpu)
-    )
 }
 
 #[test]
@@ -315,22 +249,4 @@ fn should_generate_and_byte_register_operation() {
         ))
         .generate(&cpu)
     );
-
-    assert_eq!(
-        vec![
-            Microcode::Write8bitRegister(Write8bitRegister::new(
-                register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
-                0x0f
-            )),
-            Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                register::WordRegisters::ProgramCounter,
-                2
-            ))
-        ],
-        OpcodeVariant::from(And::new(addressing_mode::ByteRegisterOperation::new(
-            register::GpRegisters::V1,
-            register::GpRegisters::V0
-        )))
-        .generate(&cpu)
-    )
 }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,7 +14,7 @@ pub trait Offset {
 }
 
 pub trait Generate<T, U> {
-    fn generate(self, cpu: &T) -> U;
+    fn generate(&self, cpu: &T) -> U;
 }
 
 /// Defines a trait for implementing transformation on a CPU, returning the

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -343,8 +343,8 @@ impl From<Operations> for Vec<Vec<Microcode>> {
 
 /// Dispatch a generate method to each corresponding generic types generate method.
 impl Generate<Mos6502, Operations> for InstructionVariant {
-    fn generate(self, cpu: &Mos6502) -> Operations {
-        match self {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
+        match *self {
             InstructionVariant::AdcAbsolute(am) => {
                 Instruction::new(mnemonic::Adc, addressing_mode::Absolute(am)).generate(cpu)
             }
@@ -1212,7 +1212,7 @@ where
 // Adc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
 
@@ -1236,7 +1236,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Adc, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1269,7 +1269,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Adc, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, cpu.y.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1302,7 +1302,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Adc, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -1334,7 +1334,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.addressing_mode.unwrap());
 
@@ -1358,7 +1358,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Adc, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1382,7 +1382,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, addr, 0);
@@ -1407,7 +1407,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Adc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Adc, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_zeropage_address(addr, cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1433,7 +1433,7 @@ impl Generate<Mos6502, Operations>
 // Sbc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
 
@@ -1457,7 +1457,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1490,7 +1490,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, cpu.y.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1523,7 +1523,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sbc, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -1555,7 +1555,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.addressing_mode.unwrap());
 
@@ -1579,7 +1579,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sbc, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1603,7 +1603,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, addr, 0);
@@ -1628,7 +1628,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sbc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sbc, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_zeropage_address(addr, cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1656,7 +1656,7 @@ impl Generate<Mos6502, Operations>
 // And
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let value = lhs & rhs;
@@ -1676,7 +1676,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::And, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -1706,7 +1706,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::And, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -1736,7 +1736,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::And, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -1764,7 +1764,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.addressing_mode.unwrap());
         let value = lhs & rhs;
@@ -1784,7 +1784,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::And, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -1804,7 +1804,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let value = lhs & rhs;
@@ -1824,7 +1824,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::And, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::And, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let lhs = Operand::new(cpu.acc.read());
@@ -1846,7 +1846,7 @@ impl Generate<Mos6502, Operations>
 // Asl
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0) << Operand::new(1u8);
 
@@ -1866,7 +1866,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Asl, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -1886,7 +1886,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mode::Accumulator> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read()) << Operand::new(1u8);
 
         Operations::new(
@@ -1903,7 +1903,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = dereference_address_to_operand(cpu, addr, 0) << Operand::new(1u8);
 
@@ -1923,7 +1923,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Asl, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Asl, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, indexed_addr, 0) << Operand::new(1u8);
@@ -1944,7 +1944,7 @@ impl Generate<Mos6502, Operations>
 // Bit
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bit, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let negative = bit_is_set(rhs.unwrap(), 7);
@@ -1964,7 +1964,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bit, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bit, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, addr, 0);
@@ -1987,7 +1987,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bit, addressing_mod
 // Eor
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let value = lhs ^ rhs;
@@ -2007,7 +2007,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Eor, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2037,7 +2037,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Eor, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2067,7 +2067,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Eor, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -2095,7 +2095,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.addressing_mode.unwrap());
         let value = lhs ^ rhs;
@@ -2115,7 +2115,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Eor, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -2135,7 +2135,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let value = lhs ^ rhs;
@@ -2155,7 +2155,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Eor, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Eor, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let lhs = Operand::new(cpu.acc.read());
@@ -2177,7 +2177,7 @@ impl Generate<Mos6502, Operations>
 // Lsr
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0) >> Operand::new(1u8);
 
@@ -2197,7 +2197,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lsr, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2217,7 +2217,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mode::Accumulator> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read()) >> Operand::new(1u8);
 
         Operations::new(
@@ -2234,7 +2234,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = dereference_address_to_operand(cpu, addr, 0) >> Operand::new(1u8);
 
@@ -2254,7 +2254,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lsr, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lsr, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, indexed_addr, 0) >> Operand::new(1u8);
@@ -2275,7 +2275,7 @@ impl Generate<Mos6502, Operations>
 // Ora
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let value = lhs | rhs;
@@ -2295,7 +2295,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ora, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2325,7 +2325,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ora, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2355,7 +2355,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ora, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -2383,7 +2383,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = Operand::new(self.addressing_mode.unwrap());
         let value = lhs | rhs;
@@ -2403,7 +2403,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ora, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let lhs = Operand::new(cpu.acc.read());
@@ -2423,7 +2423,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let lhs = Operand::new(cpu.acc.read());
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let value = lhs | rhs;
@@ -2443,7 +2443,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ora, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ora, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let lhs = Operand::new(cpu.acc.read());
@@ -2465,7 +2465,7 @@ impl Generate<Mos6502, Operations>
 // Rol
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let lhs = dereference_address_to_operand(cpu, addr, 0);
         let value = lhs.rol(Operand::new(1u8), cpu.ps.carry);
@@ -2486,7 +2486,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Rol, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2507,7 +2507,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mode::Accumulator> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read()).rol(Operand::new(1u8), cpu.ps.carry);
 
         Operations::new(
@@ -2524,7 +2524,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let lhs = dereference_address_to_operand(cpu, addr, 0);
         let value = lhs.rol(Operand::new(1u8), cpu.ps.carry);
@@ -2545,7 +2545,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rol, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Rol, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let lhs = dereference_address_to_operand(cpu, indexed_addr, 0);
@@ -2567,7 +2567,7 @@ impl Generate<Mos6502, Operations>
 // Ror
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value =
             dereference_address_to_operand(cpu, addr, 0).ror(Operand::new(1u8), cpu.ps.carry);
@@ -2588,7 +2588,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ror, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -2609,7 +2609,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mode::Accumulator> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read()).ror(Operand::new(1u8), cpu.ps.carry);
 
         Operations::new(
@@ -2626,7 +2626,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value =
             dereference_address_to_operand(cpu, addr, 0).ror(Operand::new(1u8), cpu.ps.carry);
@@ -2647,7 +2647,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ror, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ror, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, indexed_addr, 0)
@@ -2703,7 +2703,7 @@ fn branch_on_case(
 // Bcc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bcc, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(!cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
@@ -2713,7 +2713,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bcc, addressing_mod
 // Bcs
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bcs, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(cpu.ps.carry, offset, self.offset(), self.cycles(), cpu)
@@ -2723,7 +2723,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bcs, addressing_mod
 // Beq
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Beq, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
@@ -2733,7 +2733,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Beq, addressing_mod
 // Bmi
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bmi, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(cpu.ps.negative, offset, self.offset(), self.cycles(), cpu)
@@ -2743,7 +2743,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bmi, addressing_mod
 // Bne
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bne, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(!cpu.ps.zero, offset, self.offset(), self.cycles(), cpu)
@@ -2753,7 +2753,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bne, addressing_mod
 // Bpl
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bpl, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(!cpu.ps.negative, offset, self.offset(), self.cycles(), cpu)
@@ -2763,7 +2763,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bpl, addressing_mod
 // Bvc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bvc, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(!cpu.ps.overflow, offset, self.offset(), self.cycles(), cpu)
@@ -2773,7 +2773,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bvc, addressing_mod
 // Bvs
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bvs, addressing_mode::Relative> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let offset = self.addressing_mode.unwrap();
 
         branch_on_case(cpu.ps.overflow, offset, self.offset(), self.cycles(), cpu)
@@ -2783,7 +2783,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Bvs, addressing_mod
 // Clc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Clc, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -2795,7 +2795,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Clc, addressing_mod
 // Cld
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cld, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -2807,7 +2807,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cld, addressing_mod
 // Cli
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cli, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -2822,7 +2822,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cli, addressing_mod
 // Clv
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Clv, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -2834,7 +2834,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Clv, addressing_mod
 // Cmp
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.acc.read());
         let carry = lhs >= rhs;
@@ -2855,7 +2855,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Cmp, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let base_addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(base_addr, index);
@@ -2886,7 +2886,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Cmp, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let base_addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(base_addr, index);
@@ -2917,7 +2917,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Cmp, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let base_addr = self.addressing_mode.unwrap();
         let indirect_addr = dereference_indirect_indexed_address(cpu, base_addr, index);
@@ -2946,7 +2946,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addressing_mode::Immediate(am_value) = self.addressing_mode;
         let rhs = Operand::new(am_value);
         let lhs = Operand::new(cpu.acc.read());
@@ -2968,7 +2968,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Cmp, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), index);
@@ -2990,7 +2990,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let lhs = Operand::new(cpu.acc.read());
         let carry = lhs >= rhs;
@@ -3011,7 +3011,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cmp, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Cmp, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let base_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let rhs = dereference_address_to_operand(cpu, base_addr, 0);
@@ -3034,7 +3034,7 @@ impl Generate<Mos6502, Operations>
 // Cpx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.x.read());
         let carry = lhs >= rhs;
@@ -3053,7 +3053,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addressing_mode::Immediate(am_value) = self.addressing_mode;
         let rhs = Operand::new(am_value);
         let lhs = Operand::new(cpu.x.read());
@@ -3073,7 +3073,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let lhs = Operand::new(cpu.x.read());
         let carry = lhs >= rhs;
@@ -3094,7 +3094,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpx, addressing_mod
 // Cpy
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap(), 0);
         let lhs = Operand::new(cpu.y.read());
         let carry = lhs >= rhs;
@@ -3113,7 +3113,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mode::Immediate> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addressing_mode::Immediate(am_value) = self.addressing_mode;
         let rhs = Operand::new(am_value);
         let lhs = Operand::new(cpu.y.read());
@@ -3133,7 +3133,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let rhs = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
         let lhs = Operand::new(cpu.y.read());
         let carry = lhs >= rhs;
@@ -3154,7 +3154,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Cpy, addressing_mod
 // Dec
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dec, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0) - Operand::new(1);
 
@@ -3173,7 +3173,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dec, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Dec, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3192,7 +3192,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dec, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = dereference_address_to_operand(cpu, addr, 0) - Operand::new(1);
 
@@ -3211,7 +3211,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dec, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Dec, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_zeropage_address(addr, index);
@@ -3232,7 +3232,7 @@ impl Generate<Mos6502, Operations>
 // Dex
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dex, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.x.read()) - Operand::new(1);
 
         Operations::new(
@@ -3250,7 +3250,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dex, addressing_mod
 // Dey
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dey, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.x.read()) - Operand::new(1);
 
         Operations::new(
@@ -3268,7 +3268,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Dey, addressing_mod
 // Inc
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inc, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0) + Operand::new(1);
 
@@ -3287,7 +3287,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Inc, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3306,7 +3306,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inc, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = dereference_address_to_operand(cpu, addr, 0) + Operand::new(1);
 
@@ -3325,7 +3325,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inc, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Inc, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_zeropage_address(addr, index);
@@ -3346,7 +3346,7 @@ impl Generate<Mos6502, Operations>
 // Inx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inx, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.x.read()) + Operand::new(1);
 
         Operations::new(
@@ -3364,7 +3364,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Inx, addressing_mod
 // Iny
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Iny, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.y.read()) + Operand::new(1);
 
         Operations::new(
@@ -3382,7 +3382,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Iny, addressing_mod
 // Jmp
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jmp, addressing_mode::Absolute> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
 
         Operations::new(
@@ -3394,7 +3394,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jmp, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jmp, addressing_mode::Indirect> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr = self.addressing_mode.unwrap();
         let lsb = cpu.address_map.read(indirect_addr);
         let msb = cpu.address_map.read(indirect_addr + 1);
@@ -3411,7 +3411,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jmp, addressing_mod
 // Jsr
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jsr, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
 
         // grab the stack pointer and stack pointer - 1 for storing the PC
@@ -3438,7 +3438,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Jsr, addressing_mod
 // Lda
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mode::Immediate> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         let value = Operand::new(self.addressing_mode.unwrap());
 
         Operations::new(
@@ -3454,7 +3454,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
 
         Operations::new(
@@ -3472,7 +3472,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lda, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, addr as u16, 0);
@@ -3490,7 +3490,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addressing_mode::Absolute(addr) = self.addressing_mode;
         let value = Operand::new(cpu.address_map.read(addr));
         Operations::new(
@@ -3508,7 +3508,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Lda, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lda, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3536,7 +3536,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lda, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3564,7 +3564,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lda, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let zpage_base_addr = self.addressing_mode.unwrap();
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, zpage_base_addr, cpu.y.read());
@@ -3592,7 +3592,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Lda, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let value = Operand::new(cpu.address_map.read(indirect_addr));
@@ -3612,7 +3612,7 @@ impl Generate<Mos6502, Operations>
 // Ldx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0);
 
@@ -3631,7 +3631,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ldx, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3657,7 +3657,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mode::Immediate> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         let value = Operand::new(self.addressing_mode.unwrap());
 
         Operations::new(
@@ -3673,7 +3673,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
 
         Operations::new(
@@ -3691,7 +3691,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldx, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ldx, addressing_mode::ZeroPageIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, addr as u16, 0);
@@ -3711,7 +3711,7 @@ impl Generate<Mos6502, Operations>
 // Ldy
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = dereference_address_to_operand(cpu, addr, 0);
 
@@ -3730,7 +3730,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ldy, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = self.addressing_mode.unwrap();
         let indexed_addr = add_index_to_address(addr, index);
@@ -3756,7 +3756,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mode::Immediate> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         let value = Operand::new(self.addressing_mode.unwrap());
 
         Operations::new(
@@ -3772,7 +3772,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = dereference_address_to_operand(cpu, self.addressing_mode.unwrap() as u16, 0);
 
         Operations::new(
@@ -3790,7 +3790,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Ldy, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Ldy, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = dereference_address_to_operand(cpu, addr as u16, 0);
@@ -3810,7 +3810,7 @@ impl Generate<Mos6502, Operations>
 // Pha
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Pha, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = cpu.acc.read();
         let sp = cpu.sp.read();
 
@@ -3828,7 +3828,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Pha, addressing_mod
 // Php
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Php, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = cpu.ps.read();
         let sp = cpu.sp.read();
 
@@ -3846,7 +3846,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Php, addressing_mod
 // Pla
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Pla, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let sp = cpu.sp.read().overflowing_add(1).0;
         let value = dereference_address_to_operand(cpu, stack_pointer_from_byte_value(sp), 0);
 
@@ -3866,7 +3866,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Pla, addressing_mod
 // Plp
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Plp, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let sp = cpu.sp.read().overflowing_add(1).0;
         let value = dereference_address_to_operand(cpu, stack_pointer_from_byte_value(sp), 0);
 
@@ -3884,7 +3884,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Plp, addressing_mod
 // Rti
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rti, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         // grab the program status
         let sp_psl: u16 = stack_pointer_from_byte_value(cpu.sp.read().wrapping_add(1));
         let sp = cpu.address_map.read(sp_psl);
@@ -3912,7 +3912,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rti, addressing_mod
 // Rts
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rts, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         // grab the stack pointer and stack pointer - 1 for storing the PC
         let spl: u16 = stack_pointer_from_byte_value(cpu.sp.read().wrapping_add(1));
         let sph: u16 = stack_pointer_from_byte_value(cpu.sp.read().wrapping_add(2));
@@ -3934,7 +3934,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Rts, addressing_mod
 // Sec
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sec, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -3946,7 +3946,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sec, addressing_mod
 // Sed
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sed, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -3958,7 +3958,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sed, addressing_mod
 // Sei
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sei, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(
             self.offset(),
             self.cycles(),
@@ -3970,7 +3970,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sei, addressing_mod
 // Sta
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sta, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addressing_mode::Absolute(addr) = self.addressing_mode;
         let acc_val = cpu.acc.read();
         Operations::new(
@@ -3984,7 +3984,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sta, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sta, addressing_mode::AbsoluteIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_address(self.addressing_mode.unwrap(), index);
         let acc_val = cpu.acc.read();
@@ -3999,7 +3999,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sta, addressing_mode::AbsoluteIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let indexed_addr = add_index_to_address(self.addressing_mode.unwrap(), index);
         let acc_val = cpu.acc.read();
@@ -4015,7 +4015,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sta, addressing_mode::IndirectYIndexed>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indirect_indexed_address(cpu, self.addressing_mode.unwrap(), cpu.y.read());
         let acc_val = cpu.acc.read();
@@ -4030,7 +4030,7 @@ impl Generate<Mos6502, Operations>
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sta, addressing_mode::XIndexedIndirect>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let indirect_addr =
             dereference_indexed_indirect_address(cpu, self.addressing_mode.unwrap(), cpu.x.read());
         let acc_val = cpu.acc.read();
@@ -4043,7 +4043,7 @@ impl Generate<Mos6502, Operations>
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sta, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let acc_val = cpu.acc.read();
 
@@ -4058,7 +4058,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sta, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sta, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let acc_val = cpu.acc.read();
@@ -4074,7 +4074,7 @@ impl Generate<Mos6502, Operations>
 // Stx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Stx, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = cpu.x.read();
         Operations::new(
@@ -4086,7 +4086,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Stx, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Stx, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = cpu.x.read();
 
@@ -4101,7 +4101,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Stx, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Stx, addressing_mode::ZeroPageIndexedWithY>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.y.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = cpu.x.read();
@@ -4117,7 +4117,7 @@ impl Generate<Mos6502, Operations>
 // Sty
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sty, addressing_mode::Absolute> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap();
         let value = cpu.y.read();
         Operations::new(
@@ -4129,7 +4129,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sty, addressing_mod
 }
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sty, addressing_mode::ZeroPage> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let addr = self.addressing_mode.unwrap() as u16;
         let value = cpu.y.read();
 
@@ -4144,7 +4144,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Sty, addressing_mod
 impl Generate<Mos6502, Operations>
     for Instruction<mnemonic::Sty, addressing_mode::ZeroPageIndexedWithX>
 {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let index = cpu.x.read();
         let indexed_addr = add_index_to_zeropage_address(self.addressing_mode.unwrap(), index);
         let value = cpu.y.read();
@@ -4160,7 +4160,7 @@ impl Generate<Mos6502, Operations>
 // Tax
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tax, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read());
 
         Operations::new(
@@ -4178,7 +4178,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tax, addressing_mod
 // Tay
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tay, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.acc.read());
 
         Operations::new(
@@ -4196,7 +4196,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tay, addressing_mod
 // Tsx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tsx, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.sp.read());
 
         Operations::new(
@@ -4214,7 +4214,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tsx, addressing_mod
 // Txa
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Txa, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.x.read());
 
         Operations::new(
@@ -4232,7 +4232,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Txa, addressing_mod
 // Tsx
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Txs, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.x.read());
 
         Operations::new(
@@ -4249,7 +4249,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Txs, addressing_mod
 // Tya
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tya, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let value = Operand::new(cpu.y.read());
 
         Operations::new(
@@ -4269,7 +4269,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Tya, addressing_mod
 // Brk
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Brk, addressing_mode::Implied> {
-    fn generate(self, cpu: &Mos6502) -> Operations {
+    fn generate(&self, cpu: &Mos6502) -> Operations {
         let ps = cpu.ps.read();
 
         let sp_pcl: u16 = stack_pointer_from_byte_value(cpu.sp.read());
@@ -4306,7 +4306,7 @@ impl Generate<Mos6502, Operations> for Instruction<mnemonic::Brk, addressing_mod
 // Nop
 
 impl Generate<Mos6502, Operations> for Instruction<mnemonic::Nop, addressing_mode::Implied> {
-    fn generate(self, _: &Mos6502) -> Operations {
+    fn generate(&self, _: &Mos6502) -> Operations {
         Operations::new(self.offset(), self.cycles(), vec![])
     }
 }


### PR DESCRIPTION
# Introduction
This PR completes implementing `ExecuteMut` for the other ISAs and to deduplicate code, updates the old `Execute` implementations to safely wrap the mutable implementations.

# Linked Issues
resolves #271 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
