### PR TITLE
Implement `OR Vx, Vy` instruction

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -189,6 +189,9 @@ impl Iterator for Chip8IntoIterator {
     }
 }
 
+// microcode execution
+
+// For any implementation of ExecuteMut<M> for a given CPU Execute is implemented.
 impl<M> crate::cpu::Execute<Chip8> for M
 where
     Chip8: ExecuteMut<M>,

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -189,7 +189,10 @@ impl Iterator for Chip8IntoIterator {
     }
 }
 
-impl crate::cpu::Execute<Chip8> for microcode::Microcode {
+impl<M> crate::cpu::Execute<Chip8> for M
+where
+    Chip8: ExecuteMut<M>,
+{
     fn execute(self, mut cpu: Chip8) -> Chip8 {
         cpu.execute_mut(&self);
         cpu
@@ -212,23 +215,9 @@ impl crate::cpu::ExecuteMut<microcode::Microcode> for Chip8 {
     }
 }
 
-impl crate::cpu::Execute<Chip8> for microcode::WriteMemory {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
-        cpu.execute_mut(&self);
-        cpu
-    }
-}
-
 impl crate::cpu::ExecuteMut<microcode::WriteMemory> for Chip8 {
     fn execute_mut(&mut self, mc: &microcode::WriteMemory) {
         self.address_space.write(mc.address, mc.value).unwrap();
-    }
-}
-
-impl crate::cpu::Execute<Chip8> for microcode::Write8bitRegister {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -247,13 +236,6 @@ impl crate::cpu::ExecuteMut<microcode::Write8bitRegister> for Chip8 {
                 self.st = ClockDecrementing::with_value(mc.value);
             }
         }
-    }
-}
-
-impl crate::cpu::Execute<Chip8> for microcode::Inc8bitRegister {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -281,21 +263,8 @@ impl crate::cpu::ExecuteMut<microcode::Inc8bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::Execute<Chip8> for microcode::Dec8bitRegister {
-    fn execute(self, cpu: Chip8) -> Chip8 {
-        cpu
-    }
-}
-
 impl crate::cpu::ExecuteMut<microcode::Dec8bitRegister> for Chip8 {
     fn execute_mut(&mut self, _: &microcode::Dec8bitRegister) {}
-}
-
-impl crate::cpu::Execute<Chip8> for microcode::Write16bitRegister {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
-        cpu.execute_mut(&self);
-        cpu
-    }
 }
 
 impl crate::cpu::ExecuteMut<microcode::Write16bitRegister> for Chip8 {
@@ -308,13 +277,6 @@ impl crate::cpu::ExecuteMut<microcode::Write16bitRegister> for Chip8 {
                 self.pc = register::ProgramCounter::with_value(mc.value);
             }
         }
-    }
-}
-
-impl crate::cpu::Execute<Chip8> for microcode::Inc16bitRegister {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -333,30 +295,12 @@ impl crate::cpu::ExecuteMut<microcode::Inc16bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::Execute<Chip8> for microcode::Dec16bitRegister {
-    fn execute(self, cpu: Chip8) -> Chip8 {
-        cpu
-    }
-}
-
 impl crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8 {
     fn execute_mut(&mut self, _: &microcode::Dec16bitRegister) {}
 }
 
-impl crate::cpu::Execute<Chip8> for microcode::PushStack {
-    fn execute(self, cpu: Chip8) -> Chip8 {
-        cpu
-    }
-}
-
 impl crate::cpu::ExecuteMut<microcode::PushStack> for Chip8 {
     fn execute_mut(&mut self, _: &microcode::PushStack) {}
-}
-
-impl crate::cpu::Execute<Chip8> for microcode::PopStack {
-    fn execute(self, cpu: Chip8) -> Chip8 {
-        cpu
-    }
 }
 
 impl crate::cpu::ExecuteMut<microcode::PopStack> for Chip8 {

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -250,3 +250,48 @@ fn should_generate_and_byte_register_operation() {
         .generate(&cpu)
     );
 }
+
+#[test]
+fn should_parse_or_byte_register_operation_opcode() {
+    let input: Vec<(usize, u8)> = 0x8011u16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Or::new(addressing_mode::ByteRegisterOperation::new(
+                register::GpRegisters::V1,
+                register::GpRegisters::V0
+            ))
+        }),
+        <Or<addressing_mode::ByteRegisterOperation>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_or_byte_register_operation() {
+    let cpu = Chip8::default()
+        .with_gp_register(
+            register::GpRegisters::V0,
+            register::GeneralPurpose::<u8>::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GpRegisters::V1,
+            register::GeneralPurpose::<u8>::with_value(0x0f),
+        );
+    assert_eq!(
+        vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+            register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
+            0xff
+        ))],
+        Or::new(addressing_mode::ByteRegisterOperation::new(
+            register::GpRegisters::V1,
+            register::GpRegisters::V0
+        ))
+        .generate(&cpu)
+    );
+}

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -273,18 +273,13 @@ impl Iterator for Mos6502IntoIterator {
 
 // microcode execution
 
-impl Execute<Mos6502> for microcode::Microcode {
-    fn execute(self, cpu: Mos6502) -> Mos6502 {
-        match self {
-            Self::WriteMemory(mc) => mc.execute(cpu),
-            Self::SetProgramStatusFlagState(mc) => mc.execute(cpu),
-            Self::Write8bitRegister(mc) => mc.execute(cpu),
-            Self::Inc8bitRegister(mc) => mc.execute(cpu),
-            Self::Dec8bitRegister(mc) => mc.execute(cpu),
-            Self::Write16bitRegister(mc) => mc.execute(cpu),
-            Self::Inc16bitRegister(mc) => mc.execute(cpu),
-            Self::Dec16bitRegister(mc) => mc.execute(cpu),
-        }
+impl<M> crate::cpu::Execute<Mos6502> for M
+where
+    Mos6502: ExecuteMut<M>,
+{
+    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
+        cpu.execute_mut(&self);
+        cpu
     }
 }
 
@@ -303,23 +298,9 @@ impl ExecuteMut<microcode::Microcode> for Mos6502 {
     }
 }
 
-impl Execute<Mos6502> for microcode::WriteMemory {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
-    }
-}
-
 impl ExecuteMut<microcode::WriteMemory> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::WriteMemory) {
         self.address_map.write(mc.address, mc.value).unwrap();
-    }
-}
-
-impl Execute<Mos6502> for microcode::SetProgramStatusFlagState {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -341,13 +322,6 @@ impl ExecuteMut<microcode::SetProgramStatusFlagState> for Mos6502 {
     }
 }
 
-impl Execute<Mos6502> for microcode::Write8bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
-    }
-}
-
 impl ExecuteMut<microcode::Write8bitRegister> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::Write8bitRegister) {
         let register = mc.register;
@@ -366,13 +340,6 @@ impl ExecuteMut<microcode::Write8bitRegister> for Mos6502 {
             ByteRegisters::Sp => self.sp = StackPointer::with_value(value),
             ByteRegisters::Ps => self.ps = ProcessorStatus::with_value(value),
         }
-    }
-}
-
-impl Execute<Mos6502> for microcode::Inc8bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -406,13 +373,6 @@ impl ExecuteMut<microcode::Inc8bitRegister> for Mos6502 {
     }
 }
 
-impl Execute<Mos6502> for microcode::Dec8bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
-    }
-}
-
 impl ExecuteMut<microcode::Dec8bitRegister> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::Dec8bitRegister) {
         let register = mc.register;
@@ -443,23 +403,9 @@ impl ExecuteMut<microcode::Dec8bitRegister> for Mos6502 {
     }
 }
 
-impl Execute<Mos6502> for microcode::Write16bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
-    }
-}
-
 impl ExecuteMut<microcode::Write16bitRegister> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::Write16bitRegister) {
         self.pc = ProgramCounter::with_value(mc.value);
-    }
-}
-
-impl Execute<Mos6502> for microcode::Inc16bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 
@@ -467,13 +413,6 @@ impl ExecuteMut<microcode::Inc16bitRegister> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::Inc16bitRegister) {
         let pc = self.pc.read().overflowing_add(mc.value).0;
         self.pc = ProgramCounter::with_value(pc);
-    }
-}
-
-impl Execute<Mos6502> for microcode::Dec16bitRegister {
-    fn execute(self, mut cpu: Mos6502) -> Mos6502 {
-        cpu.execute_mut(&self);
-        cpu
     }
 }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -273,6 +273,7 @@ impl Iterator for Mos6502IntoIterator {
 
 // microcode execution
 
+// For any implementation of ExecuteMut<M> for a given CPU Execute is implemented.
 impl<M> crate::cpu::Execute<Mos6502> for M
 where
     Mos6502: ExecuteMut<M>,


### PR DESCRIPTION
# Introduction
This pr implements the `OR Vx, Vy` opcode for the chip-8 ISA.


Additionally this cleans up a ton of code duplication by generically implementing the `Execute<Cpu>` traits against their `ExecuteMut` counterparts for both the `mos6502` and `chip-8` targets

# Linked Issues
resolves #239 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
