### PR TITLE
Implement `LD Vx, DT` instruction

### DIFF
--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -168,34 +168,34 @@ impl Default for ByteRegisterTx {
 /// Represents a register to register operation transfering a value from a
 /// register to the Sound Timer register.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SoundTimerTx {
+pub struct SoundTimerDestTx {
     pub src: register::GpRegisters,
 }
 
-impl AddressingMode for SoundTimerTx {}
+impl AddressingMode for SoundTimerDestTx {}
 
-impl SoundTimerTx {
+impl SoundTimerDestTx {
     pub fn new(src: register::GpRegisters) -> Self {
         Self { src }
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], SoundTimerTx> for SoundTimerTx {
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], SoundTimerDestTx> for SoundTimerDestTx {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], SoundTimerTx> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], SoundTimerDestTx> {
         parcel::take_n(parcel::parsers::byte::any_byte(), 2)
             .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
             .map(|[[_, first], _]| {
                 std::convert::TryFrom::<u8>::try_from(0x0f & first).expect(NIBBLE_OVERFLOW)
             })
-            .map(SoundTimerTx::new)
+            .map(SoundTimerDestTx::new)
             .parse(input)
     }
 }
 
-impl Default for SoundTimerTx {
+impl Default for SoundTimerDestTx {
     fn default() -> Self {
         Self {
             src: register::GpRegisters::V0,
@@ -206,37 +206,75 @@ impl Default for SoundTimerTx {
 /// Represents a register to register operation transfering a value from a
 /// register to the Delay Timer register.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct DelayTimerTx {
+pub struct DelayTimerDestTx {
     pub src: register::GpRegisters,
 }
 
-impl AddressingMode for DelayTimerTx {}
+impl AddressingMode for DelayTimerDestTx {}
 
-impl DelayTimerTx {
+impl DelayTimerDestTx {
     pub fn new(src: register::GpRegisters) -> Self {
         Self { src }
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], DelayTimerTx> for DelayTimerTx {
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], DelayTimerDestTx> for DelayTimerDestTx {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], DelayTimerTx> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], DelayTimerDestTx> {
         parcel::take_n(parcel::parsers::byte::any_byte(), 2)
             .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
             .map(|[[_, first], _]| {
                 std::convert::TryFrom::<u8>::try_from(0x0f & first).expect(NIBBLE_OVERFLOW)
             })
-            .map(DelayTimerTx::new)
+            .map(DelayTimerDestTx::new)
             .parse(input)
     }
 }
 
-impl Default for DelayTimerTx {
+impl Default for DelayTimerDestTx {
     fn default() -> Self {
         Self {
             src: register::GpRegisters::V0,
+        }
+    }
+}
+
+/// Represents a register to register operation transfering a value from a
+/// register to the Delay Timer register.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DelayTimerSrcTx {
+    pub dest: register::GpRegisters,
+}
+
+impl AddressingMode for DelayTimerSrcTx {}
+
+impl DelayTimerSrcTx {
+    pub fn new(dest: register::GpRegisters) -> Self {
+        Self { dest }
+    }
+}
+
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], DelayTimerSrcTx> for DelayTimerSrcTx {
+    fn parse(
+        &self,
+        input: &'a [(usize, u8)],
+    ) -> parcel::ParseResult<&'a [(usize, u8)], DelayTimerSrcTx> {
+        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
+            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
+            .map(|[[_, first], _]| {
+                std::convert::TryFrom::<u8>::try_from(0x0f & first).expect(NIBBLE_OVERFLOW)
+            })
+            .map(DelayTimerSrcTx::new)
+            .parse(input)
+    }
+}
+
+impl Default for DelayTimerSrcTx {
+    fn default() -> Self {
+        Self {
+            dest: register::GpRegisters::V0,
         }
     }
 }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -202,16 +202,16 @@ fn should_parse_load_byte_into_sound_timer_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Ld::new(addressing_mode::SoundTimerTx::new(
+            inner: Ld::new(addressing_mode::SoundTimerDestTx::new(
                 register::GpRegisters::V8,
             ))
         }),
-        <Ld<addressing_mode::SoundTimerTx>>::default().parse(&input[..])
+        <Ld<addressing_mode::SoundTimerDestTx>>::default().parse(&input[..])
     );
 }
 
 #[test]
-fn should_generate_load_byte_into_delay_timer_operation() {
+fn should_generate_load_byte_into_sound_timer_operation() {
     let cpu = Chip8::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
@@ -221,7 +221,7 @@ fn should_generate_load_byte_into_delay_timer_operation() {
             register::ByteRegisters::TimerRegisters(register::TimerRegisters::Sound),
             0xff
         ))],
-        Ld::new(addressing_mode::SoundTimerTx::new(
+        Ld::new(addressing_mode::SoundTimerDestTx::new(
             register::GpRegisters::V0,
         ))
         .generate(&cpu)
@@ -240,26 +240,64 @@ fn should_parse_load_byte_into_delay_timer_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Ld::new(addressing_mode::DelayTimerTx::new(
+            inner: Ld::new(addressing_mode::DelayTimerDestTx::new(
                 register::GpRegisters::V8,
             ))
         }),
-        <Ld<addressing_mode::DelayTimerTx>>::default().parse(&input[..])
+        <Ld<addressing_mode::DelayTimerDestTx>>::default().parse(&input[..])
     );
 }
 
 #[test]
-fn should_generate_load_byte_into_sound_timer_operation() {
+fn should_generate_load_byte_into_delay_timer_operation() {
     let cpu = Chip8::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
     assert_eq!(
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-            register::ByteRegisters::TimerRegisters(register::TimerRegisters::Sound),
+            register::ByteRegisters::TimerRegisters(register::TimerRegisters::Delay),
             0xff
         ))],
-        Ld::new(addressing_mode::SoundTimerTx::new(
+        Ld::new(addressing_mode::DelayTimerDestTx::new(
+            register::GpRegisters::V0,
+        ))
+        .generate(&cpu)
+    );
+}
+
+#[test]
+fn should_parse_load_byte_into_register_fromdelay_timer_opcode() {
+    let input: Vec<(usize, u8)> = 0xF807u16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Ld::new(addressing_mode::DelayTimerSrcTx::new(
+                register::GpRegisters::V8,
+            ))
+        }),
+        <Ld<addressing_mode::DelayTimerSrcTx>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_load_byte_into_register_from_delay_timer_operation() {
+    let cpu = Chip8::default().with_timer_register(
+        register::TimerRegisters::Delay,
+        register::ClockDecrementing::with_value(0xff),
+    );
+    assert_eq!(
+        vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+            register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
+            0xff
+        ))],
+        Ld::new(addressing_mode::DelayTimerSrcTx::new(
             register::GpRegisters::V0,
         ))
         .generate(&cpu)


### PR DESCRIPTION
# Introduction
This PR implements the `LD Vx, DT` instruction for the CHIP-8 ISA. Additionally this PR fixes a bunch of other small issues from the `LD DT, Vx` instruction.

# Linked Issues
resolves #254 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
