### PR TITLE
Implement `Se Vx, Vy` opcode for the CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -120,27 +120,39 @@ impl Default for IRegisterIndexed {
     }
 }
 
-/// Represents a register to register operation containing both a destination
-/// and source register as the second and third nibble in a two byte opcode.
+/// Represents a register to register general-purpose operation.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ByteRegisterTx {
-    pub src: register::GpRegisters,
-    pub dest: register::GpRegisters,
+pub struct VxVy {
+    /// Represents the first register defined in this address mode. Often
+    /// times this will represent a destination register.
+    ///
+    /// # Example
+    ///
+    /// `<mnemonic> <first> <second>` or `Add <first> <second>`
+    pub first: register::GpRegisters,
+
+    /// Represents the second register defined in this address mode. Often
+    /// times this will represent a source register.
+    ///
+    /// # Example
+    ///
+    /// `<mnemonic> <first> <second>` or `Add <first> <second>`
+    pub second: register::GpRegisters,
 }
 
-impl AddressingMode for ByteRegisterTx {}
+impl AddressingMode for VxVy {}
 
-impl ByteRegisterTx {
+impl VxVy {
     pub fn new(src: register::GpRegisters, dest: register::GpRegisters) -> Self {
-        Self { src, dest }
+        Self {
+            first: src,
+            second: dest,
+        }
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], ByteRegisterTx> for ByteRegisterTx {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], ByteRegisterTx> {
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], VxVy> for VxVy {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], VxVy> {
         parcel::take_n(parcel::parsers::byte::any_byte(), 2)
             .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
             .map(|[[_, first], [second, _]]| {
@@ -151,16 +163,16 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], ByteRegisterTx> for ByteRegisterT
 
                 (src, dest)
             })
-            .map(|(src, dest)| ByteRegisterTx::new(src, dest))
+            .map(|(src, dest)| VxVy::new(src, dest))
             .parse(input)
     }
 }
 
-impl Default for ByteRegisterTx {
+impl Default for VxVy {
     fn default() -> Self {
         Self {
-            src: register::GpRegisters::V0,
-            dest: register::GpRegisters::V0,
+            first: register::GpRegisters::V0,
+            second: register::GpRegisters::V0,
         }
     }
 }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -80,7 +80,7 @@ impl<'a> Parser<'a, &'a [(usize, u8)], Box<dyn Generate<Chip8, Vec<Microcode>>>>
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
             <Ld<addressing_mode::Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
-            <Ld<addressing_mode::ByteRegisterTx>>::default()
+            <Ld<addressing_mode::VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
             <Ld<addressing_mode::SoundTimerDestTx>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
@@ -92,11 +92,11 @@ impl<'a> Parser<'a, &'a [(usize, u8)], Box<dyn Generate<Chip8, Vec<Microcode>>>>
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
             <Add<addressing_mode::IRegisterIndexed>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
-            <And<addressing_mode::ByteRegisterTx>>::default()
+            <And<addressing_mode::VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
-            <Or<addressing_mode::ByteRegisterTx>>::default()
+            <Or<addressing_mode::VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
-            <Xor<addressing_mode::ByteRegisterTx>>::default()
+            <Xor<addressing_mode::VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8, Vec<Microcode>>>),
         ])
         .parse(input)
@@ -277,13 +277,13 @@ impl Generate<Chip8, Vec<Microcode>> for Ld<addressing_mode::Immediate> {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::ByteRegisterTx>>
-    for Ld<addressing_mode::ByteRegisterTx>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::VxVy>>
+    for Ld<addressing_mode::VxVy>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::ByteRegisterTx>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::VxVy>> {
         matches_first_nibble_without_taking_input(0x8)
             .peek_next(
                 // discard the first byte since the previous parser takes nothing.
@@ -291,18 +291,18 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::ByteRegisterT
                     parcel::parsers::byte::any_byte().predicate(|v| v.to_lower_nibble() == 0x0)
                 }),
             )
-            .and_then(|_| addressing_mode::ByteRegisterTx::default())
+            .and_then(|_| addressing_mode::VxVy::default())
             .map(Ld::new)
             .parse(input)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for Ld<addressing_mode::ByteRegisterTx> {
+impl Generate<Chip8, Vec<Microcode>> for Ld<addressing_mode::VxVy> {
     fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
-        let src_val = cpu.read_gp_register(self.addressing_mode.src);
+        let src_val = cpu.read_gp_register(self.addressing_mode.first);
 
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-            register::ByteRegisters::GpRegisters(self.addressing_mode.dest),
+            register::ByteRegisters::GpRegisters(self.addressing_mode.second),
             src_val,
         ))]
     }
@@ -504,13 +504,13 @@ impl<A> And<A> {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], And<addressing_mode::ByteRegisterTx>>
-    for And<addressing_mode::ByteRegisterTx>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], And<addressing_mode::VxVy>>
+    for And<addressing_mode::VxVy>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], And<addressing_mode::ByteRegisterTx>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], And<addressing_mode::VxVy>> {
         matches_first_nibble_without_taking_input(0x8)
             .peek_next(
                 // discard the first byte since the previous parser takes nothing.
@@ -518,20 +518,20 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], And<addressing_mode::ByteRegister
                     parcel::parsers::byte::any_byte().predicate(|&v| v.to_lower_nibble() == 0x02)
                 }),
             )
-            .and_then(|_| addressing_mode::ByteRegisterTx::default())
+            .and_then(|_| addressing_mode::VxVy::default())
             .map(And::new)
             .parse(input)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for And<addressing_mode::ByteRegisterTx> {
+impl Generate<Chip8, Vec<Microcode>> for And<addressing_mode::VxVy> {
     fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
-        let src_val = cpu.read_gp_register(self.addressing_mode.src);
-        let dest_val = cpu.read_gp_register(self.addressing_mode.dest);
+        let src_val = cpu.read_gp_register(self.addressing_mode.first);
+        let dest_val = cpu.read_gp_register(self.addressing_mode.second);
         let result = dest_val & src_val;
 
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-            register::ByteRegisters::GpRegisters(self.addressing_mode.dest),
+            register::ByteRegisters::GpRegisters(self.addressing_mode.second),
             result,
         ))]
     }
@@ -549,13 +549,13 @@ impl<A> Or<A> {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Or<addressing_mode::ByteRegisterTx>>
-    for Or<addressing_mode::ByteRegisterTx>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Or<addressing_mode::VxVy>>
+    for Or<addressing_mode::VxVy>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Or<addressing_mode::ByteRegisterTx>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Or<addressing_mode::VxVy>> {
         matches_first_nibble_without_taking_input(0x8)
             .peek_next(
                 // discard the first byte since the previous parser takes nothing.
@@ -563,20 +563,20 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Or<addressing_mode::ByteRegisterT
                     parcel::parsers::byte::any_byte().predicate(|v| v.to_lower_nibble() == 0x01)
                 }),
             )
-            .and_then(|_| addressing_mode::ByteRegisterTx::default())
+            .and_then(|_| addressing_mode::VxVy::default())
             .map(Or::new)
             .parse(input)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for Or<addressing_mode::ByteRegisterTx> {
+impl Generate<Chip8, Vec<Microcode>> for Or<addressing_mode::VxVy> {
     fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
-        let src_val = cpu.read_gp_register(self.addressing_mode.src);
-        let dest_val = cpu.read_gp_register(self.addressing_mode.dest);
+        let src_val = cpu.read_gp_register(self.addressing_mode.first);
+        let dest_val = cpu.read_gp_register(self.addressing_mode.second);
         let result = dest_val | src_val;
 
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-            register::ByteRegisters::GpRegisters(self.addressing_mode.dest),
+            register::ByteRegisters::GpRegisters(self.addressing_mode.second),
             result,
         ))]
     }
@@ -594,13 +594,13 @@ impl<A> Xor<A> {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Xor<addressing_mode::ByteRegisterTx>>
-    for Xor<addressing_mode::ByteRegisterTx>
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Xor<addressing_mode::VxVy>>
+    for Xor<addressing_mode::VxVy>
 {
     fn parse(
         &self,
         input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Xor<addressing_mode::ByteRegisterTx>> {
+    ) -> parcel::ParseResult<&'a [(usize, u8)], Xor<addressing_mode::VxVy>> {
         matches_first_nibble_without_taking_input(0x8)
             .peek_next(
                 // discard the first byte since the previous parser takes nothing.
@@ -608,20 +608,20 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Xor<addressing_mode::ByteRegister
                     parcel::parsers::byte::any_byte().predicate(|v| v.to_lower_nibble() == 0x03)
                 }),
             )
-            .and_then(|_| addressing_mode::ByteRegisterTx::default())
+            .and_then(|_| addressing_mode::VxVy::default())
             .map(Xor::new)
             .parse(input)
     }
 }
 
-impl Generate<Chip8, Vec<Microcode>> for Xor<addressing_mode::ByteRegisterTx> {
+impl Generate<Chip8, Vec<Microcode>> for Xor<addressing_mode::VxVy> {
     fn generate(&self, cpu: &Chip8) -> Vec<Microcode> {
-        let src_val = cpu.read_gp_register(self.addressing_mode.src);
-        let dest_val = cpu.read_gp_register(self.addressing_mode.dest);
+        let src_val = cpu.read_gp_register(self.addressing_mode.first);
+        let dest_val = cpu.read_gp_register(self.addressing_mode.second);
         let result = dest_val ^ src_val;
 
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-            register::ByteRegisters::GpRegisters(self.addressing_mode.dest),
+            register::ByteRegisters::GpRegisters(self.addressing_mode.second),
             result,
         ))]
     }

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -569,3 +569,66 @@ fn should_generate_xor_byte_register_operation() {
         .generate(&cpu)
     );
 }
+
+#[test]
+fn should_parse_se_byte_register_operation_opcode() {
+    let input: Vec<(usize, u8)> = 0x5010u16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Se::new(addressing_mode::VxVy::new(
+                register::GpRegisters::V1,
+                register::GpRegisters::V0
+            ))
+        }),
+        <Se<addressing_mode::VxVy>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_se_byte_register_operation() {
+    let cpu_eq = Chip8::default()
+        .with_gp_register(
+            register::GpRegisters::V0,
+            register::GeneralPurpose::<u8>::with_value(0x0f),
+        )
+        .with_gp_register(
+            register::GpRegisters::V1,
+            register::GeneralPurpose::<u8>::with_value(0x0f),
+        );
+    assert_eq!(
+        vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+            register::WordRegisters::ProgramCounter,
+            2
+        ))],
+        Se::new(addressing_mode::VxVy::new(
+            register::GpRegisters::V1,
+            register::GpRegisters::V0
+        ))
+        .generate(&cpu_eq)
+    );
+
+    let cpu_ne = Chip8::default()
+        .with_gp_register(
+            register::GpRegisters::V0,
+            register::GeneralPurpose::<u8>::with_value(0xff),
+        )
+        .with_gp_register(
+            register::GpRegisters::V1,
+            register::GeneralPurpose::<u8>::with_value(0x0f),
+        );
+    assert_eq!(
+        Vec::<Microcode>::new(),
+        Se::new(addressing_mode::VxVy::new(
+            register::GpRegisters::V1,
+            register::GpRegisters::V0
+        ))
+        .generate(&cpu_ne)
+    );
+}

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -157,12 +157,12 @@ fn should_parse_load_byte_register_operation_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Ld::new(addressing_mode::ByteRegisterTx::new(
+            inner: Ld::new(addressing_mode::VxVy::new(
                 register::GpRegisters::V1,
                 register::GpRegisters::V0
             ))
         }),
-        <Ld<addressing_mode::ByteRegisterTx>>::default().parse(&input[..])
+        <Ld<addressing_mode::VxVy>>::default().parse(&input[..])
     );
 }
 
@@ -182,7 +182,7 @@ fn should_generate_load_byte_register_operation() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
             0x0f
         ))],
-        Ld::new(addressing_mode::ByteRegisterTx::new(
+        Ld::new(addressing_mode::VxVy::new(
             register::GpRegisters::V1,
             register::GpRegisters::V0
         ))
@@ -447,12 +447,12 @@ fn should_parse_and_byte_register_operation_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: And::new(addressing_mode::ByteRegisterTx::new(
+            inner: And::new(addressing_mode::VxVy::new(
                 register::GpRegisters::V1,
                 register::GpRegisters::V0
             ))
         }),
-        <And<addressing_mode::ByteRegisterTx>>::default().parse(&input[..])
+        <And<addressing_mode::VxVy>>::default().parse(&input[..])
     );
 }
 
@@ -472,7 +472,7 @@ fn should_generate_and_byte_register_operation() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
             0x0f
         ))],
-        And::new(addressing_mode::ByteRegisterTx::new(
+        And::new(addressing_mode::VxVy::new(
             register::GpRegisters::V1,
             register::GpRegisters::V0
         ))
@@ -492,12 +492,12 @@ fn should_parse_or_byte_register_operation_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Or::new(addressing_mode::ByteRegisterTx::new(
+            inner: Or::new(addressing_mode::VxVy::new(
                 register::GpRegisters::V1,
                 register::GpRegisters::V0
             ))
         }),
-        <Or<addressing_mode::ByteRegisterTx>>::default().parse(&input[..])
+        <Or<addressing_mode::VxVy>>::default().parse(&input[..])
     );
 }
 
@@ -517,7 +517,7 @@ fn should_generate_or_byte_register_operation() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
             0xff
         ))],
-        Or::new(addressing_mode::ByteRegisterTx::new(
+        Or::new(addressing_mode::VxVy::new(
             register::GpRegisters::V1,
             register::GpRegisters::V0
         ))
@@ -537,12 +537,12 @@ fn should_parse_xor_byte_register_operation_opcode() {
         Ok(MatchStatus::Match {
             span: 0..2,
             remainder: &input[2..],
-            inner: Xor::new(addressing_mode::ByteRegisterTx::new(
+            inner: Xor::new(addressing_mode::VxVy::new(
                 register::GpRegisters::V1,
                 register::GpRegisters::V0
             ))
         }),
-        <Xor<addressing_mode::ByteRegisterTx>>::default().parse(&input[..])
+        <Xor<addressing_mode::VxVy>>::default().parse(&input[..])
     );
 }
 
@@ -562,7 +562,7 @@ fn should_generate_xor_byte_register_operation() {
             register::ByteRegisters::GpRegisters(register::GpRegisters::V0),
             0xf0
         ))],
-        Xor::new(addressing_mode::ByteRegisterTx::new(
+        Xor::new(addressing_mode::VxVy::new(
             register::GpRegisters::V1,
             register::GpRegisters::V0
         ))


### PR DESCRIPTION
# Introduction
This PR implements the `Se Vx, Vy` opcode for the CHIP-8 ISA. In addition it also renames the `ByteRegisterTx` addressing mode simply to `VxVy` as some instructions using this addressing mode don't necessarily facilitate a transfer of values between registers.
# Linked Issues
resolves #235 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
