### PR TITLE
Implement a random number generator abstraction

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -13,6 +13,7 @@ mod u12;
 
 /// Defines a trait for implementing random number generation.
 pub trait GenerateRandom<T> {
+    /// Random should return a value of a constrained type T on each invocation.
     fn random(&self) -> T;
 }
 
@@ -27,7 +28,7 @@ where
 
 /// Generates a random byte using `/dev/random` as the seed for data.
 #[derive(Default, Debug, Clone, Copy)]
-pub struct UnixRandomNumberGenerator {}
+pub struct UnixRandomNumberGenerator;
 
 impl GenerateRandom<u8> for UnixRandomNumberGenerator {
     fn random(&self) -> u8 {

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -11,12 +11,45 @@ mod operations;
 mod register;
 mod u12;
 
+/// Defines a minimal trait for random number generation.
+pub trait GenerateRandom<T> {
+    fn random(&self) -> T;
+}
+
+/// Generates a constant 0 value.
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) struct ZeroValueGenerator;
+
+impl GenerateRandom<u8> for ZeroValueGenerator {
+    fn random(&self) -> u8 {
+        0
+    }
+}
+
+/// Generates a random byte using `/etc/random` as the seed for data.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct EtcRandomNumberGenerator {}
+
+impl GenerateRandom<u8> for EtcRandomNumberGenerator {
+    fn random(&self) -> u8 {
+        use std::fs;
+        use std::io::prelude::*;
+
+        let mut buf: [u8; 1] = [0];
+        fs::File::open("/dev/random")
+            .and_then(|mut f| f.read_exact(&mut buf))
+            .expect("cannot read exactly one byte from /dev/random.");
+
+        buf[0]
+    }
+}
+
 /// Represents the address the program counter is set to on chip reset.
 const RESET_PC_VECTOR: u16 = 0x200;
 
 /// Chip8 represents a CHIP-8 CPU.
 #[derive(Debug, Clone)]
-pub struct Chip8 {
+pub struct Chip8<R> {
     stack: memory::Ring<u16>,
     address_space: AddressMap<u16, u8>,
     dt: register::ClockDecrementing,
@@ -25,9 +58,10 @@ pub struct Chip8 {
     sp: register::StackPointer,
     i: register::GeneralPurpose<u16>,
     gp_registers: [register::GeneralPurpose<u8>; 0xf],
+    rng: R,
 }
 
-impl Chip8 {
+impl<R> Chip8<R> {
     pub fn with_pc_register(mut self, reg: register::ProgramCounter) -> Self {
         self.pc = reg;
         self
@@ -73,14 +107,22 @@ impl Chip8 {
             // Should never fail due to bounded array.
             .unwrap()
     }
+}
 
+impl<R> Chip8<R>
+where
+    R: Default,
+{
     /// Resets a cpu to a clean state.
     pub fn reset() -> Self {
         Self::default()
     }
 }
 
-impl Default for Chip8 {
+impl<R> Default for Chip8<R>
+where
+    R: Default,
+{
     fn default() -> Self {
         type Rom =
             crate::address_map::memory::Memory<crate::address_map::memory::ReadOnly, u16, u8>;
@@ -100,12 +142,16 @@ impl Default for Chip8 {
             sp: register::StackPointer::default(),
             i: register::GeneralPurpose::default(),
             gp_registers: [register::GeneralPurpose::default(); 0xf],
+            rng: <R>::default(),
         }
     }
 }
 
-impl Cpu<Chip8> for Chip8 {
-    fn run(self, cycles: usize) -> StepState<Chip8> {
+impl<R> Cpu<Chip8<R>> for Chip8<R>
+where
+    R: 'static + Clone,
+{
+    fn run(self, cycles: usize) -> StepState<Chip8<R>> {
         let state = self
             .clone()
             .into_iter()
@@ -116,39 +162,48 @@ impl Cpu<Chip8> for Chip8 {
     }
 }
 
-impl Cpu<Chip8> for StepState<Chip8> {
-    fn run(self, cycles: usize) -> StepState<Chip8> {
+impl<R> Cpu<Chip8<R>> for StepState<Chip8<R>>
+where
+    R: 'static + Clone,
+{
+    fn run(self, cycles: usize) -> Self {
         // CHIP-8 instructions are all single cycle. It's always ready.
         self.unwrap().run(cycles)
     }
 }
 
-impl IntoIterator for Chip8 {
+impl<R> IntoIterator for Chip8<R>
+where
+    R: 'static + Clone,
+{
     type Item = Vec<microcode::Microcode>;
-    type IntoIter = Chip8IntoIterator;
+    type IntoIter = Chip8IntoIterator<R>;
 
     fn into_iter(self) -> Self::IntoIter {
         Chip8IntoIterator::new(self)
     }
 }
 
-pub struct Chip8IntoIterator {
-    state: Chip8,
+pub struct Chip8IntoIterator<R> {
+    state: Chip8<R>,
 }
 
-impl From<Chip8IntoIterator> for Chip8 {
-    fn from(src: Chip8IntoIterator) -> Self {
+impl<R> From<Chip8IntoIterator<R>> for Chip8<R> {
+    fn from(src: Chip8IntoIterator<R>) -> Self {
         src.state
     }
 }
 
-impl Chip8IntoIterator {
-    fn new(state: Chip8) -> Self {
+impl<R> Chip8IntoIterator<R> {
+    fn new(state: Chip8<R>) -> Self {
         Chip8IntoIterator { state }
     }
 }
 
-impl Iterator for Chip8IntoIterator {
+impl<R> Iterator for Chip8IntoIterator<R>
+where
+    R: 'static + Clone,
+{
     type Item = Vec<microcode::Microcode>;
 
     fn next(&mut self) -> Option<Vec<microcode::Microcode>> {
@@ -192,17 +247,17 @@ impl Iterator for Chip8IntoIterator {
 // microcode execution
 
 // For any implementation of ExecuteMut<M> for a given CPU Execute is implemented.
-impl<M> crate::cpu::Execute<Chip8> for M
+impl<M, R> crate::cpu::Execute<Chip8<R>> for M
 where
-    Chip8: ExecuteMut<M>,
+    Chip8<R>: ExecuteMut<M>,
 {
-    fn execute(self, mut cpu: Chip8) -> Chip8 {
+    fn execute(self, mut cpu: Chip8<R>) -> Chip8<R> {
         cpu.execute_mut(&self);
         cpu
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Microcode> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Microcode> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::Microcode) {
         match mc {
             microcode::Microcode::WriteMemory(mc) => self.execute_mut(mc),
@@ -218,13 +273,13 @@ impl crate::cpu::ExecuteMut<microcode::Microcode> for Chip8 {
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::WriteMemory> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::WriteMemory> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::WriteMemory) {
         self.address_space.write(mc.address, mc.value).unwrap();
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Write8bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Write8bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::Write8bitRegister) {
         use register::{ByteRegisters, ClockDecrementing, GeneralPurpose, TimerRegisters};
 
@@ -242,7 +297,7 @@ impl crate::cpu::ExecuteMut<microcode::Write8bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Inc8bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Inc8bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::Inc8bitRegister) {
         use register::{ByteRegisters, ClockDecrementing, GeneralPurpose, TimerRegisters};
 
@@ -266,11 +321,11 @@ impl crate::cpu::ExecuteMut<microcode::Inc8bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Dec8bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Dec8bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::Dec8bitRegister) {}
 }
 
-impl crate::cpu::ExecuteMut<microcode::Write16bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Write16bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::Write16bitRegister) {
         match mc.register {
             register::WordRegisters::I => {
@@ -283,7 +338,7 @@ impl crate::cpu::ExecuteMut<microcode::Write16bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Inc16bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Inc16bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::Inc16bitRegister) {
         match mc.register {
             register::WordRegisters::I => {
@@ -298,15 +353,15 @@ impl crate::cpu::ExecuteMut<microcode::Inc16bitRegister> for Chip8 {
     }
 }
 
-impl crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::Dec16bitRegister) {}
 }
 
-impl crate::cpu::ExecuteMut<microcode::PushStack> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::PushStack> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::PushStack) {}
 }
 
-impl crate::cpu::ExecuteMut<microcode::PopStack> for Chip8 {
+impl<R> crate::cpu::ExecuteMut<microcode::PopStack> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::PopStack) {}
 }
 
@@ -317,7 +372,7 @@ mod tests {
 
     #[test]
     fn should_execute_infinitely_on_jump_to_reset_vector() {
-        let mut cpu = Chip8::default();
+        let mut cpu = Chip8::<ZeroValueGenerator>::default();
         cpu.address_space.write(0x200, 0x12).unwrap();
         cpu.address_space.write(0x201, 0x00).unwrap();
 
@@ -328,7 +383,7 @@ mod tests {
 
     #[test]
     fn should_execute_add_immediate() {
-        let mut cpu = Chip8::default().with_gp_register(
+        let mut cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::with_value(0x05),
         );

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::u12::u12;
-use crate::cpu::chip8::Chip8;
+use crate::cpu::chip8::{Chip8, ZeroValueGenerator};
 use crate::cpu::register::Register;
 
 #[test]
@@ -62,7 +62,7 @@ fn should_parse_jump_absolute_opcode() {
 
 #[test]
 fn should_generate_jump_absolute_with_pc_incrementer() {
-    let cpu = Chip8::default();
+    let cpu = Chip8::<ZeroValueGenerator>::default();
     assert_eq!(
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
@@ -97,7 +97,7 @@ fn should_parse_load_absolute_into_i_opcode() {
 
 #[test]
 fn should_generate_load_absolute_into_i_incrementer() {
-    let cpu = Chip8::default();
+    let cpu = Chip8::<ZeroValueGenerator>::default();
     assert_eq!(
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::I,
@@ -131,7 +131,7 @@ fn should_parse_load_immediate_into_i_opcode() {
 
 #[test]
 fn should_generate_load_immediate_into_i_incrementer() {
-    let cpu = Chip8::default();
+    let cpu = Chip8::<ZeroValueGenerator>::default();
     assert_eq!(
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
             register::ByteRegisters::GpRegisters(register::GpRegisters::V8),
@@ -168,7 +168,7 @@ fn should_parse_load_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_load_byte_register_operation() {
-    let cpu = Chip8::default()
+    let cpu = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -212,7 +212,7 @@ fn should_parse_load_byte_into_sound_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_sound_timer_operation() {
-    let cpu = Chip8::default().with_gp_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -250,7 +250,7 @@ fn should_parse_load_byte_into_delay_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_delay_timer_operation() {
-    let cpu = Chip8::default().with_gp_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -288,7 +288,7 @@ fn should_parse_load_byte_into_register_fromdelay_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_register_from_delay_timer_operation() {
-    let cpu = Chip8::default().with_timer_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_timer_register(
         register::TimerRegisters::Delay,
         register::ClockDecrementing::with_value(0xff),
     );
@@ -326,7 +326,7 @@ fn should_parse_jump_absolute_indexed_by_v0_opcode() {
 
 #[test]
 fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
-    let cpu = Chip8::default().with_gp_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::with_value(0x05),
     );
@@ -383,7 +383,7 @@ fn should_parse_add_immediate_opcode() {
 
 #[test]
 fn should_generate_add_immediate() {
-    let cpu = Chip8::default();
+    let cpu = Chip8::<ZeroValueGenerator>::default();
     assert_eq!(
         vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
@@ -419,7 +419,7 @@ fn should_parse_add_i_register_indexed_opcode() {
 
 #[test]
 fn should_generate_add_i_register_indexed() {
-    let cpu = Chip8::default().with_gp_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
         register::GpRegisters::V5,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -458,7 +458,7 @@ fn should_parse_and_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_and_byte_register_operation() {
-    let cpu = Chip8::default()
+    let cpu = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -503,7 +503,7 @@ fn should_parse_or_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_or_byte_register_operation() {
-    let cpu = Chip8::default()
+    let cpu = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -548,7 +548,7 @@ fn should_parse_xor_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_xor_byte_register_operation() {
-    let cpu = Chip8::default()
+    let cpu = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -593,7 +593,7 @@ fn should_parse_se_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_se_byte_register_operation() {
-    let cpu_eq = Chip8::default()
+    let cpu_eq = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0x0f),
@@ -614,7 +614,7 @@ fn should_generate_se_byte_register_operation() {
         .generate(&cpu_eq)
     );
 
-    let cpu_ne = Chip8::default()
+    let cpu_ne = Chip8::<ZeroValueGenerator>::default()
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -656,7 +656,7 @@ fn should_parse_rnd_immediate_operation_opcode() {
 
 #[test]
 fn should_generate_rnd_immediate_operation() {
-    let cpu = Chip8::default().with_gp_register(
+    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0x00),
     );

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::u12::u12;
-use crate::cpu::chip8::{Chip8, ZeroValueGenerator};
+use crate::cpu::chip8::Chip8;
 use crate::cpu::register::Register;
 
 #[test]
@@ -62,7 +62,7 @@ fn should_parse_jump_absolute_opcode() {
 
 #[test]
 fn should_generate_jump_absolute_with_pc_incrementer() {
-    let cpu = Chip8::<ZeroValueGenerator>::default();
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8);
     assert_eq!(
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::ProgramCounter,
@@ -97,7 +97,7 @@ fn should_parse_load_absolute_into_i_opcode() {
 
 #[test]
 fn should_generate_load_absolute_into_i_incrementer() {
-    let cpu = Chip8::<ZeroValueGenerator>::default();
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8);
     assert_eq!(
         vec![Microcode::Write16bitRegister(Write16bitRegister::new(
             register::WordRegisters::I,
@@ -131,7 +131,7 @@ fn should_parse_load_immediate_into_i_opcode() {
 
 #[test]
 fn should_generate_load_immediate_into_i_incrementer() {
-    let cpu = Chip8::<ZeroValueGenerator>::default();
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8);
     assert_eq!(
         vec![Microcode::Write8bitRegister(Write8bitRegister::new(
             register::ByteRegisters::GpRegisters(register::GpRegisters::V8),
@@ -168,7 +168,8 @@ fn should_parse_load_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_load_byte_register_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default()
+    let cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -212,7 +213,7 @@ fn should_parse_load_byte_into_sound_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_sound_timer_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -250,7 +251,7 @@ fn should_parse_load_byte_into_delay_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_delay_timer_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -288,7 +289,7 @@ fn should_parse_load_byte_into_register_fromdelay_timer_opcode() {
 
 #[test]
 fn should_generate_load_byte_into_register_from_delay_timer_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_timer_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_timer_register(
         register::TimerRegisters::Delay,
         register::ClockDecrementing::with_value(0xff),
     );
@@ -326,7 +327,7 @@ fn should_parse_jump_absolute_indexed_by_v0_opcode() {
 
 #[test]
 fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::with_value(0x05),
     );
@@ -383,7 +384,7 @@ fn should_parse_add_immediate_opcode() {
 
 #[test]
 fn should_generate_add_immediate() {
-    let cpu = Chip8::<ZeroValueGenerator>::default();
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8);
     assert_eq!(
         vec![Microcode::Inc8bitRegister(Inc8bitRegister::new(
             register::ByteRegisters::GpRegisters(register::GpRegisters::V5),
@@ -419,7 +420,7 @@ fn should_parse_add_i_register_indexed_opcode() {
 
 #[test]
 fn should_generate_add_i_register_indexed() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
         register::GpRegisters::V5,
         register::GeneralPurpose::<u8>::with_value(0xff),
     );
@@ -458,7 +459,8 @@ fn should_parse_and_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_and_byte_register_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default()
+    let cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -503,7 +505,8 @@ fn should_parse_or_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_or_byte_register_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default()
+    let cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -548,7 +551,8 @@ fn should_parse_xor_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_xor_byte_register_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default()
+    let cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -593,7 +597,8 @@ fn should_parse_se_byte_register_operation_opcode() {
 
 #[test]
 fn should_generate_se_byte_register_operation() {
-    let cpu_eq = Chip8::<ZeroValueGenerator>::default()
+    let cpu_eq = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0x0f),
@@ -614,7 +619,8 @@ fn should_generate_se_byte_register_operation() {
         .generate(&cpu_eq)
     );
 
-    let cpu_ne = Chip8::<ZeroValueGenerator>::default()
+    let cpu_ne = Chip8::<()>::default()
+        .with_rng(|| 0u8)
         .with_gp_register(
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0xff),
@@ -656,7 +662,7 @@ fn should_parse_rnd_immediate_operation_opcode() {
 
 #[test]
 fn should_generate_rnd_immediate_operation() {
-    let cpu = Chip8::<ZeroValueGenerator>::default().with_gp_register(
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
         register::GpRegisters::V0,
         register::GeneralPurpose::<u8>::with_value(0x00),
     );


### PR DESCRIPTION
# Introduction
This PR begins abstracting the `/etc/random` RNG used for the random op codes in the CHIP-8 ISA into a `GenerateRandom` trait that is associated with the CPU. This will allow iterating on the, now naive, implementation of the RNG as well as give more freedom to implement seedable/constant generators for the sake of testing.

# Linked Issues
#286 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
