### PR TITLE
Replace addressing mode with combinators on opcodes

### DIFF
--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -1,15 +1,4 @@
-use super::instruction_as_nibbles;
 use crate::cpu::chip8::{register, u12::u12};
-
-/// A placeholder constant error string until a u4 type is implemented. Other
-/// assertions are in place so that this should never be encountered.
-const NIBBLE_OVERFLOW: &str = "unreachable nibble should be limited to u4.";
-
-/// Returns a u8 representing the input byte with the most significant
-/// masked limiting the maximum value to 0x0f.
-const fn least_significant_nibble_from_u8(x: u8) -> u8 {
-    x & 0x0f
-}
 
 pub trait AddressingMode {}
 
@@ -206,19 +195,6 @@ impl AddressingMode for VxIIndirect {}
 impl VxIIndirect {
     pub fn new(src: register::GpRegisters) -> Self {
         Self { src }
-    }
-}
-
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], VxIIndirect> for VxIIndirect {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], VxIIndirect> {
-        instruction_as_nibbles()
-            .map(|[_, first, _, _]| least_significant_nibble_from_u8(first))
-            .map(|reg_id| std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW))
-            .map(VxIIndirect::new)
-            .parse(input)
     }
 }
 

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -140,19 +140,6 @@ impl SoundTimerDestTx {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], SoundTimerDestTx> for SoundTimerDestTx {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], SoundTimerDestTx> {
-        instruction_as_nibbles()
-            .map(|[_, first, _, _]| least_significant_nibble_from_u8(first))
-            .map(|reg_id| std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW))
-            .map(SoundTimerDestTx::new)
-            .parse(input)
-    }
-}
-
 impl Default for SoundTimerDestTx {
     fn default() -> Self {
         Self {
@@ -176,19 +163,6 @@ impl DelayTimerDestTx {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], DelayTimerDestTx> for DelayTimerDestTx {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], DelayTimerDestTx> {
-        instruction_as_nibbles()
-            .map(|[_, first, _, _]| least_significant_nibble_from_u8(first))
-            .map(|reg_id| std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW))
-            .map(DelayTimerDestTx::new)
-            .parse(input)
-    }
-}
-
 impl Default for DelayTimerDestTx {
     fn default() -> Self {
         Self {
@@ -209,19 +183,6 @@ impl AddressingMode for DelayTimerSrcTx {}
 impl DelayTimerSrcTx {
     pub fn new(dest: register::GpRegisters) -> Self {
         Self { dest }
-    }
-}
-
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], DelayTimerSrcTx> for DelayTimerSrcTx {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], DelayTimerSrcTx> {
-        instruction_as_nibbles()
-            .map(|[_, first, _, _]| least_significant_nibble_from_u8(first))
-            .map(|reg_id| std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW))
-            .map(DelayTimerSrcTx::new)
-            .parse(input)
     }
 }
 

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -174,27 +174,6 @@ impl VxVy {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], VxVy> for VxVy {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], VxVy> {
-        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
-            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
-            .map(|[[_, first], [second, _]]| {
-                (
-                    least_significant_nibble_from_u8(first),
-                    least_significant_nibble_from_u8(second),
-                )
-            })
-            .map(|(dest_id, src_id)| {
-                let dest = std::convert::TryFrom::<u8>::try_from(dest_id).expect(NIBBLE_OVERFLOW);
-                let src = std::convert::TryFrom::<u8>::try_from(src_id).expect(NIBBLE_OVERFLOW);
-
-                (src, dest)
-            })
-            .map(|(src, dest)| VxVy::new(src, dest))
-            .parse(input)
-    }
-}
-
 impl Default for VxVy {
     fn default() -> Self {
         Self {

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -11,14 +11,6 @@ const fn least_significant_nibble_from_u8(x: u8) -> u8 {
     x & 0x0f
 }
 
-/// Generates a u8 from two nibbles. This expectes both input values to
-/// respect the maximum value range of a nibble as the most significant bits
-/// are left shifted to accommodate the least significant bits.
-const fn u8_from_nibbles(msb: u8, lsb: u8) -> u8 {
-    let masked_lsb = least_significant_nibble_from_u8(lsb);
-    (msb << 4) | masked_lsb
-}
-
 pub trait AddressingMode {}
 
 /// Implied represents a type that explicitly implies it's addressing mode
@@ -58,24 +50,6 @@ impl AddressingMode for Immediate {}
 impl Immediate {
     pub fn new(register: register::GpRegisters, value: u8) -> Self {
         Self { register, value }
-    }
-}
-
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Immediate> for Immediate {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Immediate> {
-        instruction_as_nibbles()
-            .map(|[_, first, second, third]| {
-                (
-                    least_significant_nibble_from_u8(first),
-                    u8_from_nibbles(second, third),
-                )
-            })
-            .map(|(reg_id, value)| {
-                let reg = std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW);
-                (reg, value)
-            })
-            .map(|(register, value)| Immediate::new(register, value))
-            .parse(input)
     }
 }
 

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -47,21 +47,6 @@ impl Absolute {
     }
 }
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Absolute> for Absolute {
-    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Absolute> {
-        instruction_as_nibbles()
-            .map(|[_, first, second, third]| {
-                (
-                    least_significant_nibble_from_u8(first),
-                    u8_from_nibbles(second, third),
-                )
-            })
-            .map(|(upper, lower)| u12::new(u16::from_be_bytes([upper, lower])))
-            .map(Absolute)
-            .parse(input)
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Immediate {
     pub register: register::GpRegisters,

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -1,5 +1,5 @@
 use super::instruction_as_nibbles;
-use crate::cpu::chip8::{operations::ToNibbleBytes, register, u12::u12};
+use crate::cpu::chip8::{register, u12::u12};
 
 /// A placeholder constant error string until a u4 type is implemented. Other
 /// assertions are in place so that this should never be encountered.
@@ -74,23 +74,6 @@ impl AddressingMode for IRegisterIndexed {}
 impl IRegisterIndexed {
     pub fn new(register: register::GpRegisters) -> Self {
         Self { register }
-    }
-}
-
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], IRegisterIndexed> for IRegisterIndexed {
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], IRegisterIndexed> {
-        parcel::take_n(parcel::parsers::byte::any_byte(), 2)
-            .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
-            .map(|[[_, first], _]| first)
-            .map(|reg_id| {
-                std::convert::TryFrom::<u8>::try_from(least_significant_nibble_from_u8(reg_id))
-                    .expect(NIBBLE_OVERFLOW)
-            })
-            .map(IRegisterIndexed::new)
-            .parse(input)
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -254,8 +254,9 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<NonV0Indexed, addressing_mode:
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<NonV0Indexed, addressing_mode::Absolute>> {
-        matches_first_nibble_without_taking_input(0x1)
-            .and_then(|_| addressing_mode::Absolute::default())
+        expect_instruction_with_mask([Some(0x1), None, None, None])
+            .map(|[_, first, second, third]| u12::from_be_nibbles([first, second, third]))
+            .map(addressing_mode::Absolute::new)
             .map(Jp::new)
             .parse(input)
     }
@@ -271,6 +272,7 @@ impl<R> Generate<Chip8<R>, Vec<Microcode>> for Jp<NonV0Indexed, addressing_mode:
 }
 
 // Jp Absolute + V0
+
 impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<V0Indexed, addressing_mode::Absolute>>
     for Jp<V0Indexed, addressing_mode::Absolute>
 {
@@ -278,8 +280,9 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Jp<V0Indexed, addressing_mode::Ab
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Jp<V0Indexed, addressing_mode::Absolute>> {
-        matches_first_nibble_without_taking_input(0xb)
-            .and_then(|_| addressing_mode::Absolute::default())
+        expect_instruction_with_mask([Some(0xB), None, None, None])
+            .map(|[_, first, second, third]| u12::from_be_nibbles([first, second, third]))
+            .map(addressing_mode::Absolute::new)
             .map(Jp::new)
             .parse(input)
     }
@@ -317,8 +320,9 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::Absolute>>
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::Absolute>> {
-        matches_first_nibble_without_taking_input(0xA)
-            .and_then(|_| addressing_mode::Absolute::default())
+        expect_instruction_with_mask([Some(0xA), None, None, None])
+            .map(|[_, first, second, third]| u12::from_be_nibbles([first, second, third]))
+            .map(addressing_mode::Absolute::new)
             .map(Ld::new)
             .parse(input)
     }
@@ -545,8 +549,9 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Call<addressing_mode::Absolute>>
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Call<addressing_mode::Absolute>> {
-        matches_first_nibble_without_taking_input(0x2)
-            .and_then(|_| addressing_mode::Absolute::default())
+        expect_instruction_with_mask([Some(0x2), None, None, None])
+            .map(|[_, first, second, third]| u12::from_be_nibbles([first, second, third]))
+            .map(addressing_mode::Absolute::new)
             .map(Call::new)
             .parse(input)
     }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn expect_instruction_with_mask<'a>(
             .map(|bytes| [bytes[0].to_be_nibbles(), bytes[1].to_be_nibbles()])
             .map(|[[first, second], [third, fourth]]| [first, second, third, fourth])
             .predicate(move |nibbles| instruction_matches_nibble_mask(*nibbles, expected).is_ok())
-            .parse(&input[..])
+            .parse(input)
     }
 }
 
@@ -95,9 +95,8 @@ fn instruction_matches_nibble_mask(
         .iter()
         .zip(expected.iter())
         .map(|(&i, &e)| nibble_matches_mask(i, e))
-        .take_while(|v| *v == true)
-        .collect::<Vec<bool>>()
-        .len();
+        .take_while(|v| *v)
+        .count();
 
     if nibble_matches == 4 {
         Ok(input)

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -415,14 +415,11 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::SoundTimerDes
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::SoundTimerDestTx>> {
-        matches_first_nibble_without_taking_input(0xF)
-            .peek_next(
-                // discard the first byte since the previous parser takes nothing.
-                parcel::parsers::byte::any_byte().and_then(|_| {
-                    parcel::parsers::byte::any_byte().predicate(|&second| second == 0x18)
-                }),
-            )
-            .and_then(|_| addressing_mode::SoundTimerDestTx::default())
+        expect_instruction_with_mask([Some(0xF), None, Some(0x1), Some(0x8)])
+            .map(|[_, reg_id, _, _]| {
+                std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW)
+            })
+            .map(addressing_mode::SoundTimerDestTx::new)
             .map(Ld::new)
             .parse(input)
     }
@@ -446,14 +443,11 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::DelayTimerDes
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::DelayTimerDestTx>> {
-        matches_first_nibble_without_taking_input(0xF)
-            .peek_next(
-                // discard the first byte since the previous parser takes nothing.
-                parcel::parsers::byte::any_byte().and_then(|_| {
-                    parcel::parsers::byte::any_byte().predicate(|&second| second == 0x15)
-                }),
-            )
-            .and_then(|_| addressing_mode::DelayTimerDestTx::default())
+        expect_instruction_with_mask([Some(0xF), None, Some(0x1), Some(0x5)])
+            .map(|[_, reg_id, _, _]| {
+                std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW)
+            })
+            .map(addressing_mode::DelayTimerDestTx::new)
             .map(Ld::new)
             .parse(input)
     }
@@ -477,14 +471,11 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ld<addressing_mode::DelayTimerSrc
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Ld<addressing_mode::DelayTimerSrcTx>> {
-        matches_first_nibble_without_taking_input(0xF)
-            .peek_next(
-                // discard the first byte since the previous parser takes nothing.
-                parcel::parsers::byte::any_byte().and_then(|_| {
-                    parcel::parsers::byte::any_byte().predicate(|&second| second == 0x07)
-                }),
-            )
-            .and_then(|_| addressing_mode::DelayTimerSrcTx::default())
+        expect_instruction_with_mask([Some(0xF), None, Some(0x0), Some(0x7)])
+            .map(|[_, reg_id, _, _]| {
+                std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW)
+            })
+            .map(addressing_mode::DelayTimerSrcTx::new)
             .map(Ld::new)
             .parse(input)
     }

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -98,6 +98,7 @@ fn instruction_matches_nibble_mask(
         .take_while(|v| *v)
         .count();
 
+    // validate that all nibbles passed their mask
     if nibble_matches == 4 {
         Ok(input)
     } else {

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -622,13 +622,11 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Add<addressing_mode::IRegisterInd
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Add<addressing_mode::IRegisterIndexed>> {
-        matches_first_nibble_without_taking_input(0xf)
-            .peek_next(
-                // discard the first byte since the previous parser takes nothing.
-                parcel::parsers::byte::any_byte()
-                    .and_then(|_| parcel::parsers::byte::expect_byte(0x1e)),
-            )
-            .and_then(|_| addressing_mode::IRegisterIndexed::default())
+        expect_instruction_with_mask([Some(0xf), None, Some(0x1), Some(0xe)])
+            .map(|[_, reg_id, _, _]| {
+                std::convert::TryFrom::<u8>::try_from(reg_id).expect(NIBBLE_OVERFLOW)
+            })
+            .map(addressing_mode::IRegisterIndexed::new)
             .map(Add::new)
             .parse(input)
     }

--- a/src/cpu/chip8/u12.rs
+++ b/src/cpu/chip8/u12.rs
@@ -13,6 +13,16 @@ impl u12 {
 }
 
 impl u12 {
+    /// Takes a 3 value array representing the nibblees in a big-endian format
+    /// and attempts to covert the nibbles to a corresponding u12. All nibbles
+    /// are masked and will be truncated to a maximum value of 0x0f.
+    pub fn from_be_nibbles(src: [u8; 3]) -> u12 {
+        let masked_src = [src[0] & 0x0f, src[1] & 0x0f, src[2] & 0x0f];
+        u12::from(masked_src)
+    }
+}
+
+impl u12 {
     /// Instantiates a new u12.
     pub fn new(value: u16) -> Self {
         if value > Self::MAX.0 {
@@ -164,6 +174,16 @@ macro_rules! impl_from_u12_for_uX {
 }
 
 impl_from_u12_for_uX!(u16, u32, u64, u128,);
+
+impl From<[u8; 3]> for u12 {
+    fn from(src: [u8; 3]) -> Self {
+        let msb = src[0] & 0x0f;
+        let lsb = ((src[1] & 0x0f) << 4) | (src[2] & 0x0f);
+        let val = u16::from_be_bytes([msb, lsb]);
+
+        u12::new(val)
+    }
+}
 
 trait MaskU12 {
     fn mask(self) -> Self;


### PR DESCRIPTION
# Introduction
This PR replaces the combinators on the addressing mode with a set of nibble-masked combinators that can be applied directly in the opcodes. This strips away some additional complexity of matching on the opcode then having to reparse again at the addressing mode in favor of a simpler parser that works off a set of masked nibble values.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
