### PR TITLE
Implement `SNE vx, byte` instruction for CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -837,6 +837,61 @@ fn should_generate_xor_byte_register_operation() {
 }
 
 #[test]
+fn should_parse_se_immediate_operation_opcode() {
+    let input: Vec<(usize, u8)> = 0x30ffu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Se::new(addressing_mode::Immediate::new(
+                register::GpRegisters::V0,
+                0xff
+            ))
+        }),
+        <Se<addressing_mode::Immediate>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_se_immediate_operation() {
+    let cpu_eq = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0xff),
+    );
+
+    assert_eq!(
+        vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+            register::WordRegisters::ProgramCounter,
+            2
+        ))],
+        Se::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V0,
+            0xff
+        ))
+        .generate(&cpu_eq)
+    );
+
+    let cpu_ne = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0xff),
+    );
+
+    assert_eq!(
+        Vec::<Microcode>::new(),
+        Se::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V0,
+            0x00
+        ))
+        .generate(&cpu_ne)
+    );
+}
+
+#[test]
 fn should_parse_se_byte_register_operation_opcode() {
     let input: Vec<(usize, u8)> = 0x5010u16
         .to_be_bytes()
@@ -902,6 +957,61 @@ fn should_generate_se_byte_register_operation() {
 }
 
 #[test]
+fn should_parse_sne_immediate_operation_opcode() {
+    let input: Vec<(usize, u8)> = 0x40ffu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Sne::new(addressing_mode::Immediate::new(
+                register::GpRegisters::V0,
+                0xff
+            ))
+        }),
+        <Sne<addressing_mode::Immediate>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_sne_immediate_operation() {
+    let cpu_eq = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0xff),
+    );
+
+    assert_eq!(
+        vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+            register::WordRegisters::ProgramCounter,
+            2
+        ))],
+        Sne::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V0,
+            0x00
+        ))
+        .generate(&cpu_eq)
+    );
+
+    let cpu_ne = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0xff),
+    );
+
+    assert_eq!(
+        Vec::<Microcode>::new(),
+        Sne::new(addressing_mode::Immediate::new(
+            register::GpRegisters::V0,
+            0xff
+        ))
+        .generate(&cpu_ne)
+    );
+}
+
+#[test]
 fn should_parse_sne_byte_register_operation_opcode() {
     let input: Vec<(usize, u8)> = 0x9010u16
         .to_be_bytes()
@@ -961,61 +1071,6 @@ fn should_generate_sne_byte_register_operation() {
         Sne::new(addressing_mode::VxVy::new(
             register::GpRegisters::V1,
             register::GpRegisters::V0
-        ))
-        .generate(&cpu_ne)
-    );
-}
-
-#[test]
-fn should_parse_se_immediate_operation_opcode() {
-    let input: Vec<(usize, u8)> = 0x30ffu16
-        .to_be_bytes()
-        .iter()
-        .copied()
-        .enumerate()
-        .collect();
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..2,
-            remainder: &input[2..],
-            inner: Se::new(addressing_mode::Immediate::new(
-                register::GpRegisters::V0,
-                0xff
-            ))
-        }),
-        <Se<addressing_mode::Immediate>>::default().parse(&input[..])
-    );
-}
-
-#[test]
-fn should_generate_se_immediate_operation() {
-    let cpu_eq = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
-        register::GpRegisters::V0,
-        register::GeneralPurpose::<u8>::with_value(0xff),
-    );
-
-    assert_eq!(
-        vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
-            register::WordRegisters::ProgramCounter,
-            2
-        ))],
-        Se::new(addressing_mode::Immediate::new(
-            register::GpRegisters::V0,
-            0xff
-        ))
-        .generate(&cpu_eq)
-    );
-
-    let cpu_ne = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
-        register::GpRegisters::V0,
-        register::GeneralPurpose::<u8>::with_value(0xff),
-    );
-
-    assert_eq!(
-        Vec::<Microcode>::new(),
-        Se::new(addressing_mode::Immediate::new(
-            register::GpRegisters::V0,
-            0x00
         ))
         .generate(&cpu_ne)
     );


### PR DESCRIPTION
# Introduction
This PR implements the `SNE Vx, Byte` instruction for the CHIP-8 ISA
# Linked Issues
resolves #234
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
