### PR TITLE
Implement `CALL nnn` instruction for the CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -121,11 +121,11 @@ impl Dec16bitRegister {
 /// stack pointer.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PushStack {
-    pub value: u8,
+    pub value: u16,
 }
 
 impl PushStack {
-    pub fn new(value: u8) -> Self {
+    pub fn new(value: u16) -> Self {
         Self { value }
     }
 }

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -363,7 +363,17 @@ impl<R> crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8<R> {
 }
 
 impl<R> crate::cpu::ExecuteMut<microcode::PushStack> for Chip8<R> {
-    fn execute_mut(&mut self, _: &microcode::PushStack) {}
+    fn execute_mut(&mut self, mc: &microcode::PushStack) {
+        // decrement stack pointer before doing any data writes.
+        let sp = self.sp.read().wrapping_sub(1);
+        self.sp.write(sp);
+
+        // push the value from mc onto the new stack location.
+        // due to the protections applied by the `StackPointer`'s `.read()
+        // method this should be fairly safe to unwrap as it can't overflow 16
+        // places.
+        self.stack.write(self.sp.read() as usize, mc.value).unwrap();
+    }
 }
 
 impl<R> crate::cpu::ExecuteMut<microcode::PopStack> for Chip8<R> {

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -549,6 +549,23 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Call<addressing_mode::Absolute>>
     }
 }
 
+impl<R> Generate<Chip8<R>, Vec<Microcode>> for Call<addressing_mode::Absolute> {
+    fn generate(&self, cpu: &Chip8<R>) -> Vec<Microcode> {
+        let current_pc = cpu.pc.read();
+        let addr = self.addressing_mode.addr();
+        // decrement 2 to account for PC incrementing.
+        let inc_adjusted_addr = u16::from(addr).wrapping_sub(2);
+
+        vec![
+            Microcode::PushStack(PushStack::new(current_pc)),
+            Microcode::Write16bitRegister(Write16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                inc_adjusted_addr,
+            )),
+        ]
+    }
+}
+
 /// Adds the associated value to the value of the specified register. Setting
 /// the register to the sum.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -133,6 +133,8 @@ where
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Box<dyn Generate<Chip8<R>, Vec<Microcode>>>> {
         parcel::one_of(vec![
+            <Call<addressing_mode::Absolute>>::default()
+                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Jp<NonV0Indexed, addressing_mode::Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Jp<V0Indexed, addressing_mode::Absolute>>::default()

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -127,7 +127,7 @@ impl<'a, R> Parser<'a, &'a [(usize, u8)], Box<dyn Generate<Chip8<R>, Vec<Microco
 where
     R: 'static,
 {
-    #[allow(clippy::clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     fn parse(
         &self,
         input: &'a [(usize, u8)],

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -400,6 +400,26 @@ fn should_parse_call_opcode() {
 }
 
 #[test]
+fn should_generate_call_absolute_instruction() {
+    let cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
+        .with_pc_register(register::ProgramCounter::with_value(0x200));
+
+    assert_eq!(
+        vec![
+            // save initial value
+            Microcode::PushStack(PushStack::new(0x200)),
+            // jump to absolute value - 2.
+            Microcode::Write16bitRegister(Write16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                0x3fe
+            ))
+        ],
+        Call::new(addressing_mode::Absolute::new(u12::new(0x400))).generate(&cpu)
+    );
+}
+
+#[test]
 fn should_parse_add_immediate_opcode() {
     let input: Vec<(usize, u8)> = 0x70ffu16
         .to_be_bytes()

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -154,7 +154,7 @@ impl Default for ProcessorStatus {
 
 impl Register<u8, u8> for ProcessorStatus {
     fn read(&self) -> u8 {
-        self.clone().into()
+        (*self).into()
     }
 
     fn write(self, value: u8) -> Self {


### PR DESCRIPTION
# Introduction
This PR implements the `CALL nnn` instruction for the CHIP-8 ISA along with implementing a PushStack microcode instruction to facilitate working with the call stack.
# Linked Issues
resolves #232 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
