### PR TITLE
Implement `Ret` instruction for the CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -364,8 +364,8 @@ impl<R> crate::cpu::ExecuteMut<microcode::Dec16bitRegister> for Chip8<R> {
 
 impl<R> crate::cpu::ExecuteMut<microcode::PushStack> for Chip8<R> {
     fn execute_mut(&mut self, mc: &microcode::PushStack) {
-        // decrement stack pointer before doing any data writes.
-        let sp = self.sp.read().wrapping_sub(1);
+        // increment stack pointer before doing any data writes.
+        let sp = self.sp.read().wrapping_add(1);
         self.sp.write(sp);
 
         // push the value from mc onto the new stack location.
@@ -377,7 +377,11 @@ impl<R> crate::cpu::ExecuteMut<microcode::PushStack> for Chip8<R> {
 }
 
 impl<R> crate::cpu::ExecuteMut<microcode::PopStack> for Chip8<R> {
-    fn execute_mut(&mut self, _: &microcode::PopStack) {}
+    fn execute_mut(&mut self, _: &microcode::PopStack) {
+        // decrement stack pointer.
+        let sp = self.sp.read().wrapping_sub(1);
+        self.sp.write(sp);
+    }
 }
 
 #[cfg(test)]

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -225,7 +225,7 @@ impl<R> Generate<Chip8<R>, Vec<Microcode>> for Ret<addressing_mode::Implied> {
     fn generate(&self, cpu: &Chip8<R>) -> Vec<Microcode> {
         let current_sp = cpu.sp.read();
         let ret_pc = cpu.stack.read(current_sp as usize);
-        let inc_adjusted_addr = u16::from(ret_pc).wrapping_sub(2);
+        let inc_adjusted_addr = ret_pc.wrapping_sub(2);
 
         vec![
             Microcode::PopStack(PopStack::new(ret_pc)),

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -1,3 +1,4 @@
+use crate::address_map::SafeAddressable;
 use crate::cpu::chip8::register;
 use crate::cpu::chip8::register::GpRegisters;
 use crate::cpu::chip8::u12::u12;
@@ -215,6 +216,22 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ret<addressing_mode::Implied>>
         parcel::parsers::byte::expect_bytes(&[0x00, 0xee])
             .map(|_| Ret::default())
             .parse(input)
+    }
+}
+
+impl<R> Generate<Chip8<R>, Vec<Microcode>> for Ret<addressing_mode::Implied> {
+    fn generate(&self, cpu: &Chip8<R>) -> Vec<Microcode> {
+        let current_sp = cpu.sp.read();
+        let ret_pc = cpu.stack.read(current_sp as usize);
+        let inc_adjusted_addr = u16::from(ret_pc).wrapping_sub(2);
+
+        vec![
+            Microcode::PopStack(PopStack::new(ret_pc)),
+            Microcode::Write16bitRegister(Write16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                inc_adjusted_addr,
+            )),
+        ]
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -134,6 +134,8 @@ where
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Box<dyn Generate<Chip8<R>, Vec<Microcode>>>> {
         parcel::one_of(vec![
+            <Ret<addressing_mode::Implied>>::default()
+                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Call<addressing_mode::Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Jp<NonV0Indexed, addressing_mode::Absolute>>::default()

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -41,6 +41,28 @@ fn should_parse_ret_opcode() {
 }
 
 #[test]
+fn should_generate_ret_implied_instruction() {
+    let mut cpu = Chip8::<()>::default()
+        .with_rng(|| 0u8)
+        .with_pc_register(register::ProgramCounter::with_value(0x200));
+
+    cpu.stack.write(0x0, 0x200);
+
+    assert_eq!(
+        vec![
+            // save initial value
+            Microcode::PopStack(PopStack::new(0x200)),
+            // jump to absolute value - 2.
+            Microcode::Write16bitRegister(Write16bitRegister::new(
+                register::WordRegisters::ProgramCounter,
+                0x1fe
+            ))
+        ],
+        Ret::default().generate(&cpu)
+    );
+}
+
+#[test]
 fn should_parse_jump_absolute_opcode() {
     let input: Vec<(usize, u8)> = 0x1fffu16
         .to_be_bytes()

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-pub use crate::address_map::{Addressable, AddressableClone};
+pub use crate::address_map::{Addressable, AddressableClone, SafeAddressable};
 
 #[allow(unused_imports)]
 pub use crate::cpu::{register::Register, Cpu, Cyclable, Offset, StepState};


### PR DESCRIPTION
# Introduction
This PR implements the `Ret` instruction for the CHIP-8 ISA.
# Linked Issues
resolves #230 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
