### PR TITLE
Update references from `emulator` to `simulator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mainspring
-A CPU device and emulation framework focused on extensibility and flexibility of hardware layouts.
+A CPU and device simulation framework focused on extensibility and flexibility of hardware layouts.
 
 <!-- TOC -->
 
@@ -21,7 +21,7 @@ The framework comes with both traits and types to assist users with implementati
 
 ### Reference Implementations
 #### MOS 6502
-The [MOS 6502](https://en.wikipedia.org/wiki/MOS_Technology_6502) is the first cpu emulated in this example and is used heavily as the basis for most of the traits and examples. Basic usages and hardware layouts can be found in the [examples](./examples/) directory.
+The [MOS 6502](https://en.wikipedia.org/wiki/MOS_Technology_6502) is the first cpu simulated in this example and is used heavily as the basis for most of the traits and examples. Basic usages and hardware layouts can be found in the [examples](./examples/) directory.
 
 #### CHIP-8
 [CHIP-8](https://en.wikipedia.org/wiki/CHIP-8).

--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -1,7 +1,7 @@
 use crate::cpu::chip8::register::{ByteRegisters, WordRegisters};
 
 /// An Enumerable type to store each microcode operation possible on the
-/// CHIP-8 emulator.
+/// CHIP-8 simulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
     WriteMemory(WriteMemory),

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -5,7 +5,7 @@
 use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegisters};
 
 /// An Enumerable type to store each microcode operation possible on the
-/// 6502 emulator.
+/// 6502 simulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
     WriteMemory(WriteMemory),

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -102,7 +102,7 @@ impl Mos6502 {
         Ok(self)
     }
 
-    /// emulates the reset process of the CPU.
+    /// Simulates the reset process of the CPU.
     pub fn reset(self) -> StepState<Self> {
         let mut cpu = Mos6502::with_addressmap(self.address_map);
         let lsb: u8 = cpu.address_map.read(RESET_VECTOR_LL);
@@ -113,7 +113,7 @@ impl Mos6502 {
         StepState::new(6, cpu)
     }
 
-    /// emulates the reset process of the CPU, exporting the options as a Operations type
+    /// Simulates the reset process of the CPU, exporting the options as a Operations type
     pub fn reset_as_mops(&self) -> operations::Operations {
         let lsb: u8 = self.address_map.read(RESET_VECTOR_LL);
         let msb: u8 = self.address_map.read(RESET_VECTOR_HH);

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -191,7 +191,7 @@ impl Rol for Operand<u8> {
 
     fn rol(self, other: Self, carry: bool) -> Self::Output {
         let (lhs, rhs) = (self.unwrap(), other.unwrap());
-        let carry_in = carry as u8; // bool translates to 1 or 0 emulating 0th bit.
+        let carry_in = carry as u8; // bool translates to 1 or 0 representing 0th bit.
         let carry_out = bit_is_set(lhs, 7);
         let shifted = Operand::new(lhs << rhs | carry_in);
 


### PR DESCRIPTION
# Introduction
This PR correctly updates references calling mainspring an `emulator` to correctly reflect that it is a `simulator`.
# Linked Issues
resolves #306 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
