### PR TITLE
Implement `SKNP Vx` instruction for CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -178,6 +178,8 @@ where
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Skp>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
+            <Sknp>::default()
+                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
         ])
         .parse(input)
     }
@@ -1035,6 +1037,12 @@ impl<R> Generate<Chip8<R>, Vec<Microcode>> for Sknp {
                 2,
             ))],
         }
+    }
+}
+
+impl Default for Sknp {
+    fn default() -> Self {
+        Sknp::new(GpRegisters::V0)
     }
 }
 


### PR DESCRIPTION
# Introduction
This PR implements the `SKNP Vx` instruction for the CHIP-8 ISA.
# Linked Issues
resolves #253 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
