### PR TITLE
Remove duplication in chip8 opcode variant parser

### DIFF
--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -135,46 +135,48 @@ where
         &self,
         input: &'a [(usize, u8)],
     ) -> parcel::ParseResult<&'a [(usize, u8)], Box<dyn Generate<Chip8<R>, Vec<Microcode>>>> {
+        use addressing_mode::*;
+
         parcel::one_of(vec![
-            <Ret<addressing_mode::Implied>>::default()
+            <Ret<Implied>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Call<addressing_mode::Absolute>>::default()
+            <Call<Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Jp<NonV0Indexed, addressing_mode::Absolute>>::default()
+            <Jp<NonV0Indexed, Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Jp<V0Indexed, addressing_mode::Absolute>>::default()
+            <Jp<V0Indexed, Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<addressing_mode::Absolute>>::default()
+            <Ld<Absolute>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<addressing_mode::VxVy>>::default()
+            <Ld<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<addressing_mode::SoundTimerDestTx>>::default()
+            <Ld<SoundTimerDestTx>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<addressing_mode::DelayTimerDestTx>>::default()
+            <Ld<DelayTimerDestTx>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<addressing_mode::DelayTimerSrcTx>>::default()
+            <Ld<DelayTimerSrcTx>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <LdBcd<addressing_mode::VxIIndirect>>::default()
+            <LdBcd<VxIIndirect>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<addressing_mode::Immediate>>::default()
+            <Add<Immediate>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<addressing_mode::IRegisterIndexed>>::default()
+            <Add<IRegisterIndexed>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<addressing_mode::VxVy>>::default()
+            <Add<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Subn<addressing_mode::VxVy>>::default()
+            <Subn<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <And<addressing_mode::VxVy>>::default()
+            <And<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Or<addressing_mode::VxVy>>::default()
+            <Or<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Xor<addressing_mode::VxVy>>::default()
+            <Xor<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Se<addressing_mode::VxVy>>::default()
+            <Se<VxVy>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Se<addressing_mode::Immediate>>::default()
+            <Se<Immediate>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <StoreRegistersToMemory<addressing_mode::VxIIndirect>>::default()
+            <StoreRegistersToMemory<VxIIndirect>>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
             <Skp>::default()
                 .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -121,6 +121,18 @@ fn instruction_matches_nibble_mask(
     }
 }
 
+macro_rules! construct_microcode_generators_from_instruction_parser {
+    ($($inst:ty,)*) => {
+        vec![
+            $(
+            <$inst>::default()
+                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
+
+            )*
+        ]
+    };
+}
+
 /// Provides a Parser type for the OpcodeVariant enum. Constructing an
 /// OpcodeVariant from a stream of bytes.
 pub struct OpcodeVariantParser;
@@ -137,52 +149,30 @@ where
     ) -> parcel::ParseResult<&'a [(usize, u8)], Box<dyn Generate<Chip8<R>, Vec<Microcode>>>> {
         use addressing_mode::*;
 
-        parcel::one_of(vec![
-            <Ret<Implied>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Call<Absolute>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Jp<NonV0Indexed, Absolute>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Jp<V0Indexed, Absolute>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<Absolute>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<SoundTimerDestTx>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<DelayTimerDestTx>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Ld<DelayTimerSrcTx>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <LdBcd<VxIIndirect>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<Immediate>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<IRegisterIndexed>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Add<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Subn<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <And<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Or<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Xor<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Se<VxVy>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Se<Immediate>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <StoreRegistersToMemory<VxIIndirect>>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Skp>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-            <Sknp>::default()
-                .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
-        ])
+        parcel::one_of(construct_microcode_generators_from_instruction_parser!(
+            Ret<Implied>,
+            Call<Absolute>,
+            Jp<NonV0Indexed, Absolute>,
+            Jp<V0Indexed, Absolute>,
+            Ld<Absolute>,
+            Ld<VxVy>,
+            Ld<SoundTimerDestTx>,
+            Ld<DelayTimerDestTx>,
+            Ld<DelayTimerSrcTx>,
+            LdBcd<VxIIndirect>,
+            Add<Immediate>,
+            Add<IRegisterIndexed>,
+            Add<VxVy>,
+            Subn<VxVy>,
+            And<VxVy>,
+            Or<VxVy>,
+            Xor<VxVy>,
+            Se<VxVy>,
+            Se<Immediate>,
+            StoreRegistersToMemory<VxIIndirect>,
+            Skp,
+            Sknp,
+        ))
         .parse(input)
     }
 }

--- a/src/cpu/chip8/register.rs
+++ b/src/cpu/chip8/register.rs
@@ -15,7 +15,6 @@ pub enum WordRegisters {
 /// GpRegisters represents each type of general purpose registers,
 /// representable as a usize for indexing purposes.
 #[derive(Debug, PartialEq, Clone, Copy)]
-#[repr(usize)]
 pub enum GpRegisters {
     V0,
     V1,


### PR DESCRIPTION
# Introduction
This is a small PR to do away with the verbose and repetitive parser -> Generator conversion in the `OpcodeVariant` parser.

```rust
<$inst>::default()
        .map(|opc| Box::new(opc) as Box<dyn Generate<Chip8<R>, Vec<Microcode>>>),
```

To instead reduce the definition to a macro that takes N number of Instruction/addressing_mode pairings to interpolate into the above expression.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
