### PR TITLE
Implement `SHL Vx {, Vy}` instruction for CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -929,6 +929,68 @@ fn should_generate_or_byte_register_operation() {
 }
 
 #[test]
+fn should_parse_shl_vxvy_with_flag_operation() {
+    let input: Vec<(usize, u8)> = 0x801Eu16
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .enumerate()
+        .collect();
+    assert_eq!(
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: Shl::new(addressing_mode::VxVy::new(GpRegisters::V1, GpRegisters::V0))
+        }),
+        <Shl<addressing_mode::VxVy>>::default().parse(&input[..])
+    );
+}
+
+#[test]
+fn should_generate_shl_vxvy_with_flag_operation_that_overflows_byte_capacity() {
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0x81u8),
+    );
+
+    assert_eq!(
+        vec![
+            Microcode::Write8bitRegister(Write8bitRegister::new(
+                register::ByteRegisters::GpRegisters(GpRegisters::Vf),
+                0x01
+            )),
+            Microcode::Write8bitRegister(Write8bitRegister::new(
+                register::ByteRegisters::GpRegisters(GpRegisters::V0),
+                0x02
+            ))
+        ],
+        Shl::new(addressing_mode::VxVy::new(GpRegisters::V1, GpRegisters::V0)).generate(&cpu)
+    );
+}
+
+#[test]
+fn should_generate_shl_vxvy_with_flag_operation_that_does_not_overflow_byte_capacity() {
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8).with_gp_register(
+        register::GpRegisters::V0,
+        register::GeneralPurpose::<u8>::with_value(0x01),
+    );
+
+    assert_eq!(
+        vec![
+            Microcode::Write8bitRegister(Write8bitRegister::new(
+                register::ByteRegisters::GpRegisters(GpRegisters::Vf),
+                0x0
+            )),
+            Microcode::Write8bitRegister(Write8bitRegister::new(
+                register::ByteRegisters::GpRegisters(GpRegisters::V0),
+                0x2
+            ))
+        ],
+        Shl::new(addressing_mode::VxVy::new(GpRegisters::V1, GpRegisters::V0)).generate(&cpu)
+    );
+}
+
+#[test]
 fn should_parse_xor_byte_register_operation_opcode() {
     let input: Vec<(usize, u8)> = 0x8013u16
         .to_be_bytes()


### PR DESCRIPTION
# Introduction
This PR implements the `SHL Vx {, Vy}` instruction for CHIP-8 ISA.
# Linked Issues
resolves #246 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
