### PR TITLE
Implement `CLS` instruction for CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -178,7 +178,7 @@ type CartesianCoordinate = (usize, usize);
 /// SetDisplayPixel takes a cartesian coordinate representing a pixel and the
 /// value to set that pixel to.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct SetDisplayPixel(CartesianCoordinate, bool);
+pub struct SetDisplayPixel(pub CartesianCoordinate, pub bool);
 
 impl SetDisplayPixel {
     pub fn new(coord: CartesianCoordinate, value: bool) -> Self {

--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -18,6 +18,8 @@ pub enum Microcode {
     PopStack(PopStack),
     KeyPress(KeyPress),
     KeyRelease,
+    SetDisplayPixel(SetDisplayPixel),
+    SetDisplayRange(SetDisplayRange),
 }
 
 /// Represents a write of the value to the memory location specified by the
@@ -167,5 +169,34 @@ pub struct KeyRelease;
 impl KeyRelease {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Represents an (x, y) cartesian coordinate.
+type CartesianCoordinate = (usize, usize);
+
+/// SetDisplayPixel takes a cartesian coordinate representing a pixel and the
+/// value to set that pixel to.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct SetDisplayPixel(CartesianCoordinate, bool);
+
+impl SetDisplayPixel {
+    pub fn new(coord: CartesianCoordinate, value: bool) -> Self {
+        Self(coord, value)
+    }
+}
+
+/// SetDisplayRange takes a value representing what to set all pixels that fall
+/// within the bounds of the enclosed start and end cartesian coordinates.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct SetDisplayRange {
+    start: CartesianCoordinate,
+    end: CartesianCoordinate,
+    value: bool,
+}
+
+impl SetDisplayRange {
+    pub fn new(start: CartesianCoordinate, end: CartesianCoordinate, value: bool) -> Self {
+        Self { start, end, value }
     }
 }

--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -190,9 +190,9 @@ impl SetDisplayPixel {
 /// within the bounds of the enclosed start and end cartesian coordinates.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct SetDisplayRange {
-    start: CartesianCoordinate,
-    end: CartesianCoordinate,
-    value: bool,
+    pub start: CartesianCoordinate,
+    pub end: CartesianCoordinate,
+    pub value: bool,
 }
 
 impl SetDisplayRange {

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -361,6 +361,8 @@ impl<R> crate::cpu::ExecuteMut<microcode::Microcode> for Chip8<R> {
             microcode::Microcode::PopStack(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyPress(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyRelease => self.execute_mut(&microcode::KeyRelease),
+            microcode::Microcode::SetDisplayPixel(_) => todo!(),
+            microcode::Microcode::SetDisplayRange(_) => todo!(),
         }
     }
 }

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -66,6 +66,8 @@ pub enum KeyInputValue {
     KeyF,
 }
 
+type Display = [[bool; 64]; 32];
+
 /// Represents the address the program counter is set to on chip reset.
 const RESET_PC_VECTOR: u16 = 0x200;
 
@@ -80,6 +82,7 @@ pub struct Chip8<R> {
     sp: register::StackPointer,
     i: register::GeneralPurpose<u16>,
     gp_registers: [register::GeneralPurpose<u8>; 0xf],
+    display: Display,
     input_buffer: Option<KeyInputValue>,
     rng: R,
 }
@@ -142,6 +145,7 @@ impl<R> Chip8<R> {
             sp: self.sp,
             i: self.i,
             gp_registers: self.gp_registers,
+            display: self.display,
             input_buffer: self.input_buffer,
             rng,
         }
@@ -158,6 +162,7 @@ impl<R> Chip8<R> {
             sp: self.sp,
             i: self.i,
             gp_registers: self.gp_registers,
+            display: self.display,
             input_buffer: Some(input),
             rng: self.rng,
         }
@@ -174,6 +179,7 @@ impl<R> Chip8<R> {
             sp: self.sp,
             i: self.i,
             gp_registers: self.gp_registers,
+            display: self.display,
             input_buffer: None,
             rng: self.rng,
         }
@@ -213,6 +219,7 @@ where
             sp: register::StackPointer::default(),
             i: register::GeneralPurpose::default(),
             gp_registers: [register::GeneralPurpose::default(); 0xf],
+            display: [[false; 64]; 32],
             input_buffer: None,
             rng: <R>::default(),
         }

--- a/src/cpu/chip8/operations/addressing_mode.rs
+++ b/src/cpu/chip8/operations/addressing_mode.rs
@@ -2,16 +2,6 @@ use crate::cpu::chip8::{register, u12::u12};
 
 pub trait AddressingMode {}
 
-/// Implied represents a type that explicitly implies it's addressing mode
-/// through a 2-byte mnemonic code.
-/// # Note
-/// Implied addressing mode does not implement Parser as the parsing should be
-/// defined on the implementing opcode.
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct Implied;
-
-impl AddressingMode for Implied {}
-
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct Absolute(u12);
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -1,9 +1,9 @@
 use std::convert::TryFrom;
 
 use crate::address_map::SafeAddressable;
-use crate::cpu::chip8::register;
-use crate::cpu::chip8::register::GpRegisters;
+use crate::cpu::chip8::register::{self, GpRegisters};
 use crate::cpu::chip8::u12::u12;
+use crate::cpu::chip8::Display;
 use crate::cpu::chip8::{microcode::*, Chip8, GenerateRandom};
 use crate::cpu::Generate;
 use crate::prelude::v1::Register;
@@ -204,7 +204,11 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls> for Cls {
 
 impl<R> Generate<Chip8<R>, Vec<Microcode>> for Cls {
     fn generate(&self, _: &Chip8<R>) -> Vec<Microcode> {
-        vec![]
+        vec![Microcode::SetDisplayRange(SetDisplayRange::new(
+            (0, 0),
+            (Display::x_max(), Display::y_max()),
+            false,
+        ))]
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -159,7 +159,7 @@ where
         use addressing_mode::*;
 
         parcel::one_of(construct_microcode_generators_from_instruction_parser!(
-            Ret<Implied>,
+            Ret,
             Call<Absolute>,
             Jp<NonV0Indexed, Absolute>,
             Jp<V0Indexed, Absolute>,
@@ -191,49 +191,29 @@ where
 
 /// Clear the display.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Cls<A> {
-    addressing_mode: std::marker::PhantomData<A>,
-}
+pub struct Cls;
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls<addressing_mode::Implied>>
-    for Cls<addressing_mode::Implied>
-{
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Cls<addressing_mode::Implied>> {
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls> for Cls {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Cls> {
         parcel::parsers::byte::expect_bytes(&[0x00, 0xe0])
             .map(|_| Cls::default())
             .parse(input)
     }
 }
 
-impl From<Cls<addressing_mode::Implied>> for u16 {
-    fn from(_: Cls<addressing_mode::Implied>) -> Self {
-        0x00e0
-    }
-}
-
 /// Return from a subroutine.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Ret<A> {
-    addressing_mode: std::marker::PhantomData<A>,
-}
+pub struct Ret;
 
-impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ret<addressing_mode::Implied>>
-    for Ret<addressing_mode::Implied>
-{
-    fn parse(
-        &self,
-        input: &'a [(usize, u8)],
-    ) -> parcel::ParseResult<&'a [(usize, u8)], Ret<addressing_mode::Implied>> {
+impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Ret> for Ret {
+    fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Ret> {
         parcel::parsers::byte::expect_bytes(&[0x00, 0xee])
             .map(|_| Ret::default())
             .parse(input)
     }
 }
 
-impl<R> Generate<Chip8<R>, Vec<Microcode>> for Ret<addressing_mode::Implied> {
+impl<R> Generate<Chip8<R>, Vec<Microcode>> for Ret {
     fn generate(&self, cpu: &Chip8<R>) -> Vec<Microcode> {
         let current_sp = cpu.sp.read();
         let ret_pc = cpu.stack.read(current_sp as usize);
@@ -246,12 +226,6 @@ impl<R> Generate<Chip8<R>, Vec<Microcode>> for Ret<addressing_mode::Implied> {
                 inc_adjusted_addr,
             )),
         ]
-    }
-}
-
-impl From<Ret<addressing_mode::Implied>> for u16 {
-    fn from(_: Ret<addressing_mode::Implied>) -> Self {
-        0x00ee
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -159,6 +159,7 @@ where
         use addressing_mode::*;
 
         parcel::one_of(construct_microcode_generators_from_instruction_parser!(
+            Cls,
             Ret,
             Call<Absolute>,
             Jp<NonV0Indexed, Absolute>,
@@ -198,6 +199,12 @@ impl<'a> parcel::Parser<'a, &'a [(usize, u8)], Cls> for Cls {
         parcel::parsers::byte::expect_bytes(&[0x00, 0xe0])
             .map(|_| Cls::default())
             .parse(input)
+    }
+}
+
+impl<R> Generate<Chip8<R>, Vec<Microcode>> for Cls {
+    fn generate(&self, _: &Chip8<R>) -> Vec<Microcode> {
+        vec![]
     }
 }
 

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -25,6 +25,20 @@ fn should_parse_cls_opcode() {
 }
 
 #[test]
+fn should_generate_cls_instruction() {
+    let cpu = Chip8::<()>::default();
+
+    assert_eq!(
+        vec![Microcode::SetDisplayRange(SetDisplayRange::new(
+            (0, 0),
+            (64, 32),
+            false
+        )),],
+        Cls::default().generate(&cpu)
+    );
+}
+
+#[test]
 fn should_parse_ret_opcode() {
     let input: Vec<(usize, u8)> = 0x00eeu16
         .to_be_bytes()

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -1437,7 +1437,7 @@ fn should_generate_skp_operation() {
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0x0f),
         )
-        .with_input(chip8::KeyInputValue::KeyF);
+        .with_input(|| Some(chip8::KeyInputValue::KeyF));
 
     assert_eq!(
         vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
@@ -1448,7 +1448,9 @@ fn should_generate_skp_operation() {
     );
 
     // a cpu with an input value that doesn't match.
-    let cpu_some_ne = cpu_some_eq.clone().with_input(chip8::KeyInputValue::Key0);
+    let cpu_some_ne = cpu_some_eq
+        .clone()
+        .with_input(|| Some(chip8::KeyInputValue::Key0));
 
     assert_eq!(
         Vec::<Microcode>::new(),
@@ -1456,7 +1458,7 @@ fn should_generate_skp_operation() {
     );
 
     // a cpu without a key pressed.
-    let cpu_none = cpu_some_eq.clone().clear_input();
+    let cpu_none = cpu_some_eq.clone().with_input(|| None);
 
     assert_eq!(
         Vec::<Microcode>::new(),
@@ -1490,7 +1492,7 @@ fn should_generate_sknp_operation() {
             register::GpRegisters::V0,
             register::GeneralPurpose::<u8>::with_value(0x0f),
         )
-        .with_input(chip8::KeyInputValue::KeyF);
+        .with_input(|| Some(chip8::KeyInputValue::KeyF));
 
     assert_eq!(
         Vec::<Microcode>::new(),
@@ -1498,7 +1500,9 @@ fn should_generate_sknp_operation() {
     );
 
     // a cpu with an input value that doesn't match.
-    let cpu_some_ne = cpu_some_eq.clone().with_input(chip8::KeyInputValue::Key0);
+    let cpu_some_ne = cpu_some_eq
+        .clone()
+        .with_input(|| Some(chip8::KeyInputValue::Key0));
 
     assert_eq!(
         vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
@@ -1509,7 +1513,7 @@ fn should_generate_sknp_operation() {
     );
 
     // a cpu without a key pressed.
-    let cpu_none = cpu_some_eq.clone().clear_input();
+    let cpu_none = cpu_some_eq.clone().with_input(|| None);
 
     assert_eq!(
         vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -57,7 +57,7 @@ fn should_parse_ret_opcode() {
 }
 
 #[test]
-fn should_generate_ret_implied_instruction() {
+fn should_generate_ret_instruction() {
     let mut cpu = Chip8::<()>::default()
         .with_rng(|| 0u8)
         .with_pc_register(register::ProgramCounter::with_value(0x200));


### PR DESCRIPTION
# Introduction
This PR implements the `CLS` instruction for CHIP-8 ISA.

To accomplish this, this PR makes a few changes:
- Adds a Display type,
- Adds new microcode instructions for interacting with the display

Additionally this does a bit of cleanup to remove unnecessary addressing modes from the `CLS` and `RET` instructions.
# Linked Issues
resolves #229 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
