### PR TITLE
Update CI/CD with toolchain-rs utilities for running linting and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,3 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-  cargo_bloat:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Add cargo-bloat
-        run: cargo install cargo-bloat
-      - name: Run cargo bloat
-        run: cargo bloat --release -n 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,28 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Lint source
-      run: cargo clippy
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
   unit_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Run tests
-      run: cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+  cargo_bloat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Add cargo-bloat
+        run: cargo install cargo-bloat
+      - name: Run cargo bloat
+        run: cargo bloat --release -n 10


### PR DESCRIPTION
# Introduction
This PR makes a small change to steal the CI/CD steps from [mossy](https://github.com/ncatelli/mossy/blob/main/.github/workflows/test.yml). This includes using the `toolchain-rs` actions for `cargo-lint` and `cargo-test`.

# Linked Issues
resolves #219 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
