### PR TITLE
Implement `DRW Vx, Vy, n` instruction for the CHIP-8 ISA

### DIFF
--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -97,7 +97,7 @@ impl Display {
         // sprite starts in display boundary
         is_within_display_boundary((x, y)).then(|| {
             (0..8u8)
-                .map(|x| (0..5 as usize).map(|y| (x, y)).collect::<Vec<_>>())
+                .map(|x| (0..5usize).map(|y| (x, y)).collect::<Vec<_>>())
                 .flatten()
                 .fold(false, |collision, (x_offset, y_offset)| {
                     let bit = (font_bytes[y_offset] >> x_offset) & 0x1;

--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -1,4 +1,4 @@
-fn is_within_display_boundary(origin: (usize, usize)) -> bool {
+const fn is_within_display_boundary(origin: (usize, usize)) -> bool {
     let x = origin.0;
     let y = origin.1;
 

--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -100,7 +100,7 @@ impl Display {
                 .map(|x| (0..5usize).map(|y| (x, y)).collect::<Vec<_>>())
                 .flatten()
                 .fold(false, |collision, (x_offset, y_offset)| {
-                    let bit = (font_bytes[y_offset] >> x_offset) & 0x1;
+                    let bit = (font_bytes[y_offset] >> (7 - x_offset)) & 0x1;
                     let bit_is_set = bit != 0;
                     let adjusted_y = y + y_offset;
                     let adjusted_x = x + x_offset as usize;

--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -97,7 +97,8 @@ impl Display {
         // sprite starts in display boundary
         is_within_display_boundary((x, y)).then(|| {
             (0..8u8)
-                .zip(0..5usize)
+                .map(|x| (0..5 as usize).map(|y| (x, y)).collect::<Vec<_>>())
+                .flatten()
                 .fold(false, |collision, (x_offset, y_offset)| {
                     let bit = (font_bytes[y_offset] >> x_offset) & 0x1;
                     let bit_is_set = bit != 0;

--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -18,7 +18,6 @@ pub enum Microcode {
     PopStack(PopStack),
     KeyPress(KeyPress),
     KeyRelease,
-    SetDisplayPixel(SetDisplayPixel),
     SetDisplayRange(SetDisplayRange),
 }
 
@@ -174,17 +173,6 @@ impl KeyRelease {
 
 /// Represents an (x, y) cartesian coordinate.
 type CartesianCoordinate = (usize, usize);
-
-/// SetDisplayPixel takes a cartesian coordinate representing a pixel and the
-/// value to set that pixel to.
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct SetDisplayPixel(pub CartesianCoordinate, pub bool);
-
-impl SetDisplayPixel {
-    pub fn new(coord: CartesianCoordinate, value: bool) -> Self {
-        Self(coord, value)
-    }
-}
 
 /// SetDisplayRange takes a value representing what to set all pixels that fall
 /// within the bounds of the enclosed start and end cartesian coordinates.

--- a/src/cpu/chip8/microcode.rs
+++ b/src/cpu/chip8/microcode.rs
@@ -18,6 +18,7 @@ pub enum Microcode {
     PopStack(PopStack),
     KeyPress(KeyPress),
     KeyRelease,
+    SetDisplayPixel(SetDisplayPixel),
     SetDisplayRange(SetDisplayRange),
 }
 
@@ -173,6 +174,17 @@ impl KeyRelease {
 
 /// Represents an (x, y) cartesian coordinate.
 type CartesianCoordinate = (usize, usize);
+
+/// SetDisplayPixel takes a cartesian coordinate representing a pixel and the
+/// value to set that pixel to.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct SetDisplayPixel(pub CartesianCoordinate, pub bool);
+
+impl SetDisplayPixel {
+    pub fn new(coord: CartesianCoordinate, value: bool) -> Self {
+        Self(coord, value)
+    }
+}
 
 /// SetDisplayRange takes a value representing what to set all pixels that fall
 /// within the bounds of the enclosed start and end cartesian coordinates.

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -356,6 +356,7 @@ impl<R> crate::cpu::ExecuteMut<microcode::Microcode> for Chip8<R> {
             microcode::Microcode::PopStack(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyPress(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyRelease => self.execute_mut(&microcode::KeyRelease),
+            microcode::Microcode::SetDisplayPixel(mc) => self.execute_mut(mc),
             microcode::Microcode::SetDisplayRange(mc) => self.execute_mut(mc),
         }
     }
@@ -476,6 +477,13 @@ impl<R> crate::cpu::ExecuteMut<microcode::KeyPress> for Chip8<R> {
 impl<R> crate::cpu::ExecuteMut<microcode::KeyRelease> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::KeyRelease) {
         self.interrupt = None;
+    }
+}
+
+impl<R> crate::cpu::ExecuteMut<microcode::SetDisplayPixel> for Chip8<R> {
+    fn execute_mut(&mut self, mc: &microcode::SetDisplayPixel) {
+        let microcode::SetDisplayPixel((x, y), pixel_value) = *mc;
+        self.display.write_pixel_mut(x, y, pixel_value);
     }
 }
 

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -216,15 +216,13 @@ where
     R: Default,
 {
     fn default() -> Self {
-        type Rom =
-            crate::address_map::memory::Memory<crate::address_map::memory::ReadOnly, u16, u8>;
         type Ram =
             crate::address_map::memory::Memory<crate::address_map::memory::ReadWrite, u16, u8>;
 
         Self {
             stack: memory::Ring::new(16),
             address_space: AddressMap::default()
-                .register(0..=0x1ff, Box::new(Rom::new(0, 0x1ff)))
+                .register(0..=0x1ff, Box::new(Ram::new(0, 0x1ff)))
                 .unwrap()
                 .register(0x200..=0xfff, Box::new(Ram::new(0x200, 0xfff)))
                 .unwrap(),

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -356,7 +356,6 @@ impl<R> crate::cpu::ExecuteMut<microcode::Microcode> for Chip8<R> {
             microcode::Microcode::PopStack(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyPress(mc) => self.execute_mut(mc),
             microcode::Microcode::KeyRelease => self.execute_mut(&microcode::KeyRelease),
-            microcode::Microcode::SetDisplayPixel(mc) => self.execute_mut(mc),
             microcode::Microcode::SetDisplayRange(mc) => self.execute_mut(mc),
         }
     }
@@ -477,13 +476,6 @@ impl<R> crate::cpu::ExecuteMut<microcode::KeyPress> for Chip8<R> {
 impl<R> crate::cpu::ExecuteMut<microcode::KeyRelease> for Chip8<R> {
     fn execute_mut(&mut self, _: &microcode::KeyRelease) {
         self.interrupt = None;
-    }
-}
-
-impl<R> crate::cpu::ExecuteMut<microcode::SetDisplayPixel> for Chip8<R> {
-    fn execute_mut(&mut self, mc: &microcode::SetDisplayPixel) {
-        let microcode::SetDisplayPixel((x, y), pixel_value) = *mc;
-        self.display.write_pixel_mut(x, y, pixel_value);
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -307,8 +307,60 @@ impl Drw {
 impl<R> Generate<Chip8<R>> for Drw {
     type Item = Vec<Microcode>;
 
-    fn generate(&self, _cpu: &Chip8<R>) -> Vec<Microcode> {
-        vec![]
+    fn generate(&self, cpu: &Chip8<R>) -> Vec<Microcode> {
+        use crate::address_map::Addressable;
+
+        // setup and load sprite
+        let font_offset = cpu.i.read();
+        let sprite_size = self.sprite_byte_size;
+        let sprite_addr_space = font_offset..(font_offset + sprite_size as u16);
+        let sprite = sprite_addr_space
+            .into_iter()
+            .map(|addr| cpu.address_space.read(addr))
+            .collect::<Vec<_>>();
+
+        // setup sprite offset
+        let start_pos = (
+            cpu.read_gp_register(self.x_register),
+            cpu.read_gp_register(self.y_register),
+        );
+
+        // check for collisions.
+        let (collision, pixels) = (0..8u8).zip(0..sprite_size as usize).fold(
+            (false, vec![]),
+            |(collision, mut pixel_writes), (x_offset, y_offset)| {
+                let bit = (sprite[y_offset] >> x_offset) & 0x1;
+                let bit_is_set = bit != 0;
+                let adjusted_y = (start_pos.1 as usize) + y_offset;
+                let adjusted_x = (start_pos.0 as usize) + x_offset as usize;
+
+                let collision = match cpu.display.pixel(adjusted_x, adjusted_y) {
+                    // if the pixel is already set and is reset to true, mark a collision,
+                    Some(true) if bit_is_set == true => true,
+                    // else persist the state of collision.
+                    _ => collision,
+                };
+
+                pixel_writes.push(Microcode::SetDisplayPixel(SetDisplayPixel::new(
+                    (adjusted_x, adjusted_y),
+                    bit_is_set,
+                )));
+
+                (collision, pixel_writes)
+            },
+        );
+
+        // join the pixel and collision opcodes.
+        pixels
+            .into_iter()
+            .chain(
+                vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                    register::ByteRegisters::GpRegisters(register::GpRegisters::Vf),
+                    collision as u8,
+                ))]
+                .into_iter(),
+            )
+            .collect()
     }
 }
 

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -343,7 +343,7 @@ impl<R> Generate<Chip8<R>> for Drw {
 
                     let collision = match cpu.display.pixel(adjusted_x, adjusted_y) {
                         // if the pixel is already set and is reset to true, mark a collision,
-                        Some(true) if bit_is_set == true => true,
+                        Some(true) if bit_is_set => true,
                         // else persist the state of collision.
                         _ => collision,
                     };


### PR DESCRIPTION
# Introduction
This PR implements the `DRW Vx, Vy, n` instruction for the CHIP-8 ISA.
# Linked Issues
resolves #251 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
