### PR TITLE
Implement `SYS nnn` instruction stub for CHIP-8 isa

### DIFF
--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -80,6 +80,7 @@ pub enum Opcode {
     Cls,
     Ret,
     Drw(GpRegisters, GpRegisters, u8),
+    Sys(u12),
     Call(u12),
     JpNonV0Indexed(u12),
     JpV0Indexed(u12),
@@ -127,6 +128,8 @@ where
             Opcode::Drw(x_reg, y_reg, sprite_size) => {
                 Drw::new(*x_reg, *y_reg, *sprite_size).generate(cpu)
             }
+            // Sys is not supported anymore so this will function as a no-op.
+            Opcode::Sys(_) => vec![],
             Opcode::Call(abs) => Call::new(*abs).generate(cpu),
             Opcode::JpNonV0Indexed(abs) => Jp::<NonV0Indexed>::new(*abs).generate(cpu),
             Opcode::JpV0Indexed(abs) => Jp::<V0Indexed>::new(*abs).generate(cpu),
@@ -192,6 +195,7 @@ impl<'a> Parser<'a, &'a [(usize, u8)], Opcode> for OpcodeVariantParser {
             match [first, second, third, fourth] {
                 [0x0, 0x0, 0xe, 0x0] => Some(Opcode::Cls),
                 [0x0, 0x0, 0xe, 0xe] => Some(Opcode::Ret),
+                [0x0, _, _, _] => Some(Opcode::Sys(absolute)),
                 [0x1, _, _, _] => Some(Opcode::JpNonV0Indexed(absolute)),
                 [0x2, _, _, _] => Some(Opcode::Call(absolute)),
                 [0x3, _, _, _] => Some(Opcode::SeImmediate(dest_reg, immediate)),

--- a/src/cpu/chip8/operations/tests/mod.rs
+++ b/src/cpu/chip8/operations/tests/mod.rs
@@ -44,6 +44,7 @@ generate_parse_test!(
     should_parse_load_keypress_into_register_operation, 0xf80au16 to Opcode::LdK(GpRegisters::V8),
     should_parse_read_registers_from_memory_operation, 0xf265u16 to Opcode::ReadRegistersFromMemory(GpRegisters::V2),
     should_parse_store_registers_to_memory_operation, 0xf255u16 to Opcode::StoreRegistersToMemory(GpRegisters::V2),
+    should_parse_sys_opcode, 0x0fffu16 to Opcode::Sys(u12::new(0xfff)),
     should_parse_call_opcode, 0x2fffu16 to Opcode::Call(u12::new(0xfff)),
     should_parse_add_immediate_opcode, 0x70ffu16 to Opcode::AddImmediate(GpRegisters::V0, 0xff),
     should_parse_add_i_register_indexed_opcode, 0xf01eu16 to Opcode::AddIRegisterIndexed(GpRegisters::V0),
@@ -399,6 +400,16 @@ fn should_generate_jump_absolute_indexed_by_v0_with_pc_incrementer() {
             0x203
         )],
         Jp::<V0Indexed>::new(u12::new(0x200)).generate(&cpu)
+    );
+}
+
+#[test]
+fn should_generate_sys_absolute_instruction() {
+    let cpu = Chip8::<()>::default().with_rng(|| 0u8);
+
+    assert_eq!(
+        Vec::<Microcode>::new(),
+        Opcode::Sys(u12::new(0x200)).generate(&cpu)
     );
 }
 


### PR DESCRIPTION
# Introduction
This PR implements the `SYS nnn` instruction stub for CHIP-8 ISA. Since this instruction is no longer in use, it returns no generated operations but still successfully parses and generates a microcode Vec.

# Linked Issues
resolves #228 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
