### PR TITLE
Move microcode enclosed structs out of enum for MOS6502 microcode

### DIFF
--- a/examples/custom_peripheral_microcode_hook.rs
+++ b/examples/custom_peripheral_microcode_hook.rs
@@ -1,7 +1,7 @@
 //! A small demonstration example of mainspring showing a basic custom execution-time hook implementation.
 
 use mainspring::address_map::memory::{Memory, ReadOnly, ReadWrite};
-use mainspring::cpu::mos6502::microcode::{Microcode, WriteMemory};
+use mainspring::cpu::mos6502::microcode::Microcode;
 use mainspring::cpu::mos6502::Mos6502;
 use mainspring::cpu::Execute;
 
@@ -74,9 +74,7 @@ fn main() {
     states
         .iter()
         .map(|mc| match mc {
-            Microcode::WriteMemory(WriteMemory { address, value })
-                if (0x8000..=0x8003).contains(address) =>
-            {
+            Microcode::WriteMemory(address, value) if (0x8000..=0x8003).contains(address) => {
                 if *address == via.port_a_addr {
                     via.port_a = *value;
                     println!("{:08b}", value);

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -10,12 +10,12 @@ use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegis
 pub enum Microcode {
     WriteMemory(u16, u8),
     SetProgramStatusFlagState(ProgramStatusFlags, bool),
-    Write8bitRegister(Write8bitRegister),
-    Inc8bitRegister(Inc8bitRegister),
-    Dec8bitRegister(Dec8bitRegister),
-    Write16bitRegister(Write16bitRegister),
-    Inc16bitRegister(Inc16bitRegister),
-    Dec16bitRegister(Dec16bitRegister),
+    Write8bitRegister(ByteRegisters, u8),
+    Inc8bitRegister(ByteRegisters, u8),
+    Dec8bitRegister(ByteRegisters, u8),
+    Write16bitRegister(WordRegisters, u16),
+    Inc16bitRegister(WordRegisters, u16),
+    Dec16bitRegister(WordRegisters, u16),
 }
 
 /// Represents a write of the value to the memory location specified by the
@@ -51,7 +51,7 @@ impl SetProgramStatusFlagState {
 /// Represents a write of the specified 8-bit value to one of the 8-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Write8bitRegister {
+pub(crate) struct Write8bitRegister {
     pub register: ByteRegisters,
     pub value: u8,
 }
@@ -65,7 +65,7 @@ impl Write8bitRegister {
 /// Represents an increment of the specified 8-bit value to one of the 8-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Inc8bitRegister {
+pub(crate) struct Inc8bitRegister {
     pub register: ByteRegisters,
     pub value: u8,
 }
@@ -79,7 +79,7 @@ impl Inc8bitRegister {
 /// Represents an decrement of the specified 8-bit value to one of the 8-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Dec8bitRegister {
+pub(crate) struct Dec8bitRegister {
     pub register: ByteRegisters,
     pub value: u8,
 }
@@ -95,7 +95,7 @@ impl Dec8bitRegister {
 /// Represents a write of the specified 16-bit value to one of the 16-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Write16bitRegister {
+pub(crate) struct Write16bitRegister {
     pub register: WordRegisters,
     pub value: u16,
 }
@@ -109,7 +109,7 @@ impl Write16bitRegister {
 /// Represents an increment of the specified 16-bit value to one of the 16-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Inc16bitRegister {
+pub(crate) struct Inc16bitRegister {
     pub register: WordRegisters,
     pub value: u16,
 }
@@ -123,7 +123,7 @@ impl Inc16bitRegister {
 /// Represents an decrement of the specified 16-bit value to one of the 16-bit
 /// registers as defined by the ByteRegisters value.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Dec16bitRegister {
+pub(crate) struct Dec16bitRegister {
     pub register: WordRegisters,
     pub value: u16,
 }
@@ -132,58 +132,4 @@ impl Dec16bitRegister {
     pub fn new(register: WordRegisters, value: u16) -> Self {
         Self { register, value }
     }
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_write_8bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Write8bitRegister(
-            $crate::cpu::mos6502::microcode::Write8bitRegister::new($reg, $value),
-        )
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_inc_8bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Inc8bitRegister(
-            $crate::cpu::mos6502::microcode::Inc8bitRegister::new($reg, $value),
-        )
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_dec_8bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Dec8bitRegister(
-            $crate::cpu::mos6502::microcode::Dec8bitRegister::new($reg, $value),
-        )
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_write_16bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Write16bitRegister(
-            $crate::cpu::mos6502::microcode::Write16bitRegister::new($reg, $value),
-        )
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_inc_16bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Inc16bitRegister(
-            $crate::cpu::mos6502::microcode::Inc16bitRegister::new($reg, $value),
-        )
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_dec_16bit_register_microcode {
-    ($reg:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::Dec16bitRegister(
-            $crate::cpu::mos6502::microcode::Dec16bitRegister::new($reg, $value),
-        )
-    };
 }

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -8,13 +8,29 @@ use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegis
 /// 6502 simulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
+    /// Represents a write of the value to the memory location specified by the
+    /// address field.
     WriteMemory(u16, u8),
+    /// Represents a write of the value to the memory location specified by the
+    /// address field.
     SetProgramStatusFlagState(ProgramStatusFlags, bool),
+    /// Represents a write of the specified 8-bit value to one of the 8-bit
+    /// registers as defined by the ByteRegisters value.
     Write8bitRegister(ByteRegisters, u8),
+    /// Represents an increment of the specified 8-bit value to one of the 8-bit
+    /// registers as defined by the ByteRegisters value.
     Inc8bitRegister(ByteRegisters, u8),
+    /// Represents an decrement of the specified 8-bit value to one of the 8-bit
+    /// registers as defined by the ByteRegisters value.
     Dec8bitRegister(ByteRegisters, u8),
+    /// Represents a write of the specified 16-bit value to one of the 16-bit
+    /// registers as defined by the ByteRegisters value.
     Write16bitRegister(WordRegisters, u16),
+    /// Represents an increment of the specified 16-bit value to one of the 16-bit
+    /// registers as defined by the ByteRegisters value.
     Inc16bitRegister(WordRegisters, u16),
+    /// Represents an decrement of the specified 16-bit value to one of the 16-bit
+    /// registers as defined by the ByteRegisters value.
     Dec16bitRegister(WordRegisters, u16),
 }
 

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -9,7 +9,7 @@ use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegis
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
     WriteMemory(u16, u8),
-    SetProgramStatusFlagState(SetProgramStatusFlagState),
+    SetProgramStatusFlagState(ProgramStatusFlags, bool),
     Write8bitRegister(Write8bitRegister),
     Inc8bitRegister(Inc8bitRegister),
     Dec8bitRegister(Dec8bitRegister),
@@ -35,7 +35,7 @@ impl WriteMemory {
 /// Represents a write of the value to the memory location specified by the
 /// address field.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SetProgramStatusFlagState {
+pub(crate) struct SetProgramStatusFlagState {
     pub flag: ProgramStatusFlags,
     pub value: bool,
 }
@@ -132,15 +132,6 @@ impl Dec16bitRegister {
     pub fn new(register: WordRegisters, value: u16) -> Self {
         Self { register, value }
     }
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_flag_set_microcode {
-    ($flag:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::SetProgramStatusFlagState(
-            $crate::cpu::mos6502::microcode::SetProgramStatusFlagState::new($flag, $value),
-        )
-    };
 }
 
 #[allow(unused_macros)]

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -8,7 +8,7 @@ use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegis
 /// 6502 simulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
-    WriteMemory(WriteMemory),
+    WriteMemory(u16, u8),
     SetProgramStatusFlagState(SetProgramStatusFlagState),
     Write8bitRegister(Write8bitRegister),
     Inc8bitRegister(Inc8bitRegister),
@@ -21,7 +21,7 @@ pub enum Microcode {
 /// Represents a write of the value to the memory location specified by the
 /// address field.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteMemory {
+pub(crate) struct WriteMemory {
     pub address: u16,
     pub value: u8,
 }
@@ -132,15 +132,6 @@ impl Dec16bitRegister {
     pub fn new(register: WordRegisters, value: u16) -> Self {
         Self { register, value }
     }
-}
-
-#[allow(unused_macros)]
-macro_rules! gen_write_memory_microcode {
-    ($addr:expr, $value:expr) => {
-        $crate::cpu::mos6502::microcode::Microcode::WriteMemory(
-            $crate::cpu::mos6502::microcode::WriteMemory::new($addr, $value),
-        )
-    };
 }
 
 #[allow(unused_macros)]

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -280,7 +280,9 @@ impl ExecuteMut<microcode::Microcode> for Mos6502 {
             microcode::Microcode::WriteMemory(addr, value) => {
                 self.execute_mut(&WriteMemory::new(*addr, *value))
             }
-            microcode::Microcode::SetProgramStatusFlagState(mc) => self.execute_mut(mc),
+            microcode::Microcode::SetProgramStatusFlagState(flag, value) => {
+                self.execute_mut(&SetProgramStatusFlagState::new(*flag, *value))
+            }
             microcode::Microcode::Write8bitRegister(mc) => self.execute_mut(mc),
             microcode::Microcode::Inc8bitRegister(mc) => self.execute_mut(mc),
             microcode::Microcode::Dec8bitRegister(mc) => self.execute_mut(mc),

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -274,8 +274,12 @@ where
 
 impl ExecuteMut<microcode::Microcode> for Mos6502 {
     fn execute_mut(&mut self, mc: &microcode::Microcode) {
+        use microcode::*;
+
         match mc {
-            microcode::Microcode::WriteMemory(mc) => self.execute_mut(mc),
+            microcode::Microcode::WriteMemory(addr, value) => {
+                self.execute_mut(&WriteMemory::new(*addr, *value))
+            }
             microcode::Microcode::SetProgramStatusFlagState(mc) => self.execute_mut(mc),
             microcode::Microcode::Write8bitRegister(mc) => self.execute_mut(mc),
             microcode::Microcode::Inc8bitRegister(mc) => self.execute_mut(mc),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1227,10 +1227,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1260,10 +1260,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1293,10 +1293,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1327,10 +1327,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1351,10 +1351,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1377,10 +1377,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1402,10 +1402,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1428,10 +1428,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1454,10 +1454,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1487,10 +1487,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1520,10 +1520,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1554,10 +1554,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1578,10 +1578,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1604,10 +1604,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1629,10 +1629,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1655,10 +1655,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1681,8 +1681,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1711,8 +1711,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1741,8 +1741,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1771,8 +1771,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1791,8 +1791,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1813,8 +1813,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1833,8 +1833,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1855,8 +1855,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1876,9 +1876,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -1898,9 +1898,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -1917,9 +1917,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::Accumulat
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -1937,9 +1937,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -1958,9 +1958,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -1983,9 +1983,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Bit, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
             ],
         )
     }
@@ -2006,9 +2006,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Bit, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, overflow),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
             ],
         )
     }
@@ -2028,8 +2028,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2058,8 +2058,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2088,8 +2088,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2118,8 +2118,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2138,8 +2138,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2160,8 +2160,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2180,8 +2180,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2202,8 +2202,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2223,9 +2223,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2245,9 +2245,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2264,9 +2264,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::Accumulat
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2284,9 +2284,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2305,9 +2305,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2328,8 +2328,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2358,8 +2358,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2388,8 +2388,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2418,8 +2418,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2438,8 +2438,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2460,8 +2460,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2480,8 +2480,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2502,8 +2502,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2524,9 +2524,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2547,9 +2547,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2566,9 +2566,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::Accumulat
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2587,9 +2587,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2609,9 +2609,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2632,9 +2632,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2655,9 +2655,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2674,9 +2674,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::Accumulat
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -2695,9 +2695,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -2717,9 +2717,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -2865,7 +2865,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Clc, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, false)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Carry,
+                false,
+            )],
         )
     }
 }
@@ -2879,7 +2882,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cld, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Decimal,
+                false,
+            )],
         )
     }
 }
@@ -2893,9 +2899,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cli, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(
+            vec![Microcode::SetProgramStatusFlagState(
                 ProgramStatusFlags::Interrupt,
-                false
+                false,
             )],
         )
     }
@@ -2910,7 +2916,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Clv, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Overflow,
+                false,
+            )],
         )
     }
 }
@@ -2930,9 +2939,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -2961,9 +2970,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -2992,9 +3001,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3023,9 +3032,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3045,9 +3054,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3069,9 +3078,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3090,9 +3099,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3113,9 +3122,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cmp, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3136,9 +3145,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpx, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3158,9 +3167,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpx, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3179,9 +3188,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpx, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3202,9 +3211,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpy, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3224,9 +3233,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpy, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3245,9 +3254,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Cpy, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, carry),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, diff.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, diff.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, carry),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, diff.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, diff.zero),
             ],
         )
     }
@@ -3266,8 +3275,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -3287,8 +3296,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -3306,8 +3315,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -3327,8 +3336,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -3347,8 +3356,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dex, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
             ],
         )
@@ -3367,8 +3376,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dey, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
             ],
         )
@@ -3388,8 +3397,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -3409,8 +3418,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -3428,8 +3437,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
@@ -3449,8 +3458,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
@@ -3469,8 +3478,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inx, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3489,8 +3498,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Iny, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -3571,8 +3580,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3589,8 +3598,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3609,8 +3618,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3627,8 +3636,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3655,8 +3664,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3683,8 +3692,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3711,8 +3720,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::IndirectY
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3731,8 +3740,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::XIndexedI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -3752,8 +3761,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3780,8 +3789,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3798,8 +3807,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3816,8 +3825,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3836,8 +3845,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -3857,8 +3866,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::Absolute>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -3885,8 +3894,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::AbsoluteI
             self.offset(),
             self.cycles() + branch_penalty,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -3903,8 +3912,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::Immediate
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -3921,8 +3930,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::ZeroPage>
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -3941,8 +3950,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::ZeroPageI
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -4003,8 +4012,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Pla, addressing_mode::Implied> 
             self.cycles(),
             vec![
                 gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -4094,7 +4103,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sec, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, true)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Carry,
+                true,
+            )],
         )
     }
 }
@@ -4108,7 +4120,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sed, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Decimal,
+                true,
+            )],
         )
     }
 }
@@ -4122,7 +4137,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sei, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true)],
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Interrupt,
+                true,
+            )],
         )
     }
 }
@@ -4341,8 +4359,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tax, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -4361,8 +4379,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tay, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
@@ -4381,8 +4399,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tsx, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
@@ -4401,8 +4419,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Txa, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -4440,8 +4458,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tya, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
             ],
         )
@@ -4475,8 +4493,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Brk, addressing_mode::Implied> 
             0, // manually modified in the instruction
             self.cycles(),
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Break, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Break, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Interrupt, true),
                 Microcode::WriteMemory(sp_pcl, pcl),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(sp_pch, pch),

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -332,9 +332,7 @@ impl From<Operations> for Vec<Vec<Microcode>> {
         mcs.push(
             src.microcode
                 .into_iter()
-                .chain(
-                    vec![gen_inc_16bit_register_microcode!(WordRegisters::Pc, offset)].into_iter(),
-                )
+                .chain(vec![Microcode::Inc16bitRegister(WordRegisters::Pc, offset)].into_iter())
                 .collect(),
         );
         mcs
@@ -1231,7 +1229,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::Absolute>
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1264,7 +1262,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::AbsoluteI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1297,7 +1295,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::AbsoluteI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1331,7 +1329,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::IndirectY
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1355,7 +1353,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::Immediate
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1381,7 +1379,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::XIndexedI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1406,7 +1404,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::ZeroPage>
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1432,7 +1430,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Adc, addressing_mode::ZeroPageI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1458,7 +1456,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::Absolute>
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1491,7 +1489,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1524,7 +1522,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::AbsoluteI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1558,7 +1556,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::IndirectY
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1582,7 +1580,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::Immediate
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1608,7 +1606,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::XIndexedI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1633,7 +1631,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::ZeroPage>
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1659,7 +1657,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sbc, addressing_mode::ZeroPageI
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, overflow),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1683,7 +1681,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1713,7 +1711,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1743,7 +1741,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1773,7 +1771,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::IndirectY
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1793,7 +1791,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1815,7 +1813,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::XIndexedI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1835,7 +1833,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1857,7 +1855,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::And, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -1920,7 +1918,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::Accumulat
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2030,7 +2028,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2060,7 +2058,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2090,7 +2088,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2120,7 +2118,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::IndirectY
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2140,7 +2138,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2162,7 +2160,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::XIndexedI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2182,7 +2180,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2204,7 +2202,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Eor, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2267,7 +2265,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::Accumulat
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2330,7 +2328,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2360,7 +2358,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2390,7 +2388,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2420,7 +2418,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::IndirectY
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2440,7 +2438,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2462,7 +2460,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::XIndexedI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2482,7 +2480,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2504,7 +2502,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ora, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2569,7 +2567,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::Accumulat
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2677,7 +2675,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::Accumulat
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, value.carry),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -2737,16 +2735,16 @@ fn branch_on_case(
 ) -> Operations {
     let jmp_on_eq = (Wrapping(cpu.pc.read()) + Wrapping(branch_offset as u16)).0;
     let mc = if cond {
-        vec![gen_write_16bit_register_microcode!(
+        vec![Microcode::Write16bitRegister(
             WordRegisters::Pc,
             // handle for underflow
-            jmp_on_eq
+            jmp_on_eq,
         )]
     } else {
-        vec![gen_write_16bit_register_microcode!(
+        vec![Microcode::Write16bitRegister(
             WordRegisters::Pc,
             // handle for underflow
-            cpu.pc.read().overflowing_add(inst_offset as u16).0
+            cpu.pc.read().overflowing_add(inst_offset as u16).0,
         )]
     };
 
@@ -3358,7 +3356,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dex, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::X, 1),
             ],
         )
     }
@@ -3378,7 +3376,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dey, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Y, 1),
             ],
         )
     }
@@ -3480,7 +3478,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inx, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3500,7 +3498,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Iny, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3517,7 +3515,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Jmp, addressing_mode::Absolute>
         Operations::new(
             0,
             self.cycles(),
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, addr)],
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, addr)],
         )
     }
 }
@@ -3534,7 +3532,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Jmp, addressing_mode::Indirect>
         Operations::new(
             0,
             self.cycles(),
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, addr)],
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, addr)],
         )
     }
 }
@@ -3559,10 +3557,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Jsr, addressing_mode::Absolute>
             self.cycles(),
             vec![
                 Microcode::WriteMemory(sph, pch),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(spl, pcl),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, addr),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write16bitRegister(WordRegisters::Pc, addr),
             ],
         )
     }
@@ -3582,7 +3580,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3600,7 +3598,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3620,7 +3618,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3638,7 +3636,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3666,7 +3664,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3694,7 +3692,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3722,7 +3720,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::IndirectY
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3742,7 +3740,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lda, addressing_mode::XIndexedI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -3763,7 +3761,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3791,7 +3789,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3809,7 +3807,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3827,7 +3825,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3847,7 +3845,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldx, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -3868,7 +3866,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::Absolute>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3896,7 +3894,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::AbsoluteI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3914,7 +3912,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::Immediate
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3932,7 +3930,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::ZeroPage>
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3952,7 +3950,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ldy, addressing_mode::ZeroPageI
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -3972,7 +3970,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Pha, addressing_mode::Implied> 
             self.cycles(),
             vec![
                 Microcode::WriteMemory(stack_pointer_from_byte_value(sp), value),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
             ],
         )
     }
@@ -3992,7 +3990,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Php, addressing_mode::Implied> 
             self.cycles(),
             vec![
                 Microcode::WriteMemory(stack_pointer_from_byte_value(sp), value),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
             ],
         )
     }
@@ -4011,10 +4009,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Pla, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -4033,8 +4031,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Plp, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_8bit_register_microcode!(ByteRegisters::Ps, value.unwrap()),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write8bitRegister(ByteRegisters::Ps, value.unwrap()),
             ],
         )
     }
@@ -4061,10 +4059,10 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rti, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_8bit_register_microcode!(ByteRegisters::Ps, sp),
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 2),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, ret_addr),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write8bitRegister(ByteRegisters::Ps, sp),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 2),
+                Microcode::Write16bitRegister(WordRegisters::Pc, ret_addr),
             ],
         )
     }
@@ -4087,8 +4085,8 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rts, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 2),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, ret_addr),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 2),
+                Microcode::Write16bitRegister(WordRegisters::Pc, ret_addr),
             ],
         )
     }
@@ -4361,7 +4359,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tax, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -4381,7 +4379,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tay, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }
@@ -4401,7 +4399,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tsx, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::X, value.unwrap()),
             ],
         )
     }
@@ -4421,7 +4419,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Txa, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -4438,9 +4436,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Txs, addressing_mode::Implied> 
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_8bit_register_microcode!(
+            vec![Microcode::Write8bitRegister(
                 ByteRegisters::Sp,
-                value.unwrap()
+                value.unwrap(),
             )],
         )
     }
@@ -4460,7 +4458,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Tya, addressing_mode::Implied> 
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, value.negative),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, value.zero),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, value.unwrap()),
+                Microcode::Write8bitRegister(ByteRegisters::Acc, value.unwrap()),
             ],
         )
     }
@@ -4496,12 +4494,12 @@ impl Generate<Mos6502> for Instruction<mnemonic::Brk, addressing_mode::Implied> 
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Break, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Interrupt, true),
                 Microcode::WriteMemory(sp_pcl, pcl),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(sp_pch, pch),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(sp_ps, ps), // PS Register
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, irq_vector),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write16bitRegister(WordRegisters::Pc, irq_vector),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1879,7 +1879,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::Absolute>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -1901,7 +1901,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::AbsoluteI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -1940,7 +1940,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::ZeroPage>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -1961,7 +1961,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Asl, addressing_mode::ZeroPageI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2226,7 +2226,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::Absolute>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2248,7 +2248,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::AbsoluteI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2287,7 +2287,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::ZeroPage>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2308,7 +2308,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Lsr, addressing_mode::ZeroPageI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2527,7 +2527,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::Absolute>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2550,7 +2550,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::AbsoluteI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2590,7 +2590,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::ZeroPage>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2612,7 +2612,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Rol, addressing_mode::ZeroPageI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2635,7 +2635,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::Absolute>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2658,7 +2658,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::AbsoluteI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -2698,7 +2698,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::ZeroPage>
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -2720,7 +2720,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Ror, addressing_mode::ZeroPageI
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, value.carry),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -3268,7 +3268,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::Absolute>
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -3289,7 +3289,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::AbsoluteI
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -3308,7 +3308,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::ZeroPage>
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -3329,7 +3329,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Dec, addressing_mode::ZeroPageI
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -3390,7 +3390,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::Absolute>
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -3411,7 +3411,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::AbsoluteI
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -3430,7 +3430,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::ZeroPage>
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(addr, value.unwrap()),
+                Microcode::WriteMemory(addr, value.unwrap()),
             ],
         )
     }
@@ -3451,7 +3451,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Inc, addressing_mode::ZeroPageI
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
-                gen_write_memory_microcode!(indexed_addr, value.unwrap()),
+                Microcode::WriteMemory(indexed_addr, value.unwrap()),
             ],
         )
     }
@@ -3549,9 +3549,9 @@ impl Generate<Mos6502> for Instruction<mnemonic::Jsr, addressing_mode::Absolute>
             0,
             self.cycles(),
             vec![
-                gen_write_memory_microcode!(sph, pch),
+                Microcode::WriteMemory(sph, pch),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(spl, pcl),
+                Microcode::WriteMemory(spl, pcl),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 gen_write_16bit_register_microcode!(WordRegisters::Pc, addr),
             ],
@@ -3962,7 +3962,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Pha, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_write_memory_microcode!(stack_pointer_from_byte_value(sp), value),
+                Microcode::WriteMemory(stack_pointer_from_byte_value(sp), value),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
             ],
         )
@@ -3982,7 +3982,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Php, addressing_mode::Implied> 
             self.offset(),
             self.cycles(),
             vec![
-                gen_write_memory_microcode!(stack_pointer_from_byte_value(sp), value),
+                Microcode::WriteMemory(stack_pointer_from_byte_value(sp), value),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
             ],
         )
@@ -4138,7 +4138,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::Absolute>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, acc_val)],
+            vec![Microcode::WriteMemory(addr, acc_val)],
         )
     }
 }
@@ -4153,7 +4153,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::AbsoluteI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indexed_addr, acc_val)],
+            vec![Microcode::WriteMemory(indexed_addr, acc_val)],
         )
     }
 }
@@ -4169,7 +4169,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::AbsoluteI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indexed_addr, acc_val)],
+            vec![Microcode::WriteMemory(indexed_addr, acc_val)],
         )
     }
 }
@@ -4184,7 +4184,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::IndirectY
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indirect_addr, acc_val)],
+            vec![Microcode::WriteMemory(indirect_addr, acc_val)],
         )
     }
 }
@@ -4199,7 +4199,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::XIndexedI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indirect_addr, acc_val)],
+            vec![Microcode::WriteMemory(indirect_addr, acc_val)],
         )
     }
 }
@@ -4214,7 +4214,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::ZeroPage>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, acc_val)],
+            vec![Microcode::WriteMemory(addr, acc_val)],
         )
     }
 }
@@ -4230,7 +4230,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sta, addressing_mode::ZeroPageI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indexed_addr, acc_val)],
+            vec![Microcode::WriteMemory(indexed_addr, acc_val)],
         )
     }
 }
@@ -4246,7 +4246,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Stx, addressing_mode::Absolute>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, value)],
+            vec![Microcode::WriteMemory(addr, value)],
         )
     }
 }
@@ -4261,7 +4261,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Stx, addressing_mode::ZeroPage>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, value)],
+            vec![Microcode::WriteMemory(addr, value)],
         )
     }
 }
@@ -4277,7 +4277,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Stx, addressing_mode::ZeroPageI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indexed_addr, value)],
+            vec![Microcode::WriteMemory(indexed_addr, value)],
         )
     }
 }
@@ -4293,7 +4293,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sty, addressing_mode::Absolute>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, value)],
+            vec![Microcode::WriteMemory(addr, value)],
         )
     }
 }
@@ -4308,7 +4308,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sty, addressing_mode::ZeroPage>
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(addr, value)],
+            vec![Microcode::WriteMemory(addr, value)],
         )
     }
 }
@@ -4324,7 +4324,7 @@ impl Generate<Mos6502> for Instruction<mnemonic::Sty, addressing_mode::ZeroPageI
         Operations::new(
             self.offset(),
             self.cycles(),
-            vec![gen_write_memory_microcode!(indexed_addr, value)],
+            vec![Microcode::WriteMemory(indexed_addr, value)],
         )
     }
 }
@@ -4477,11 +4477,11 @@ impl Generate<Mos6502> for Instruction<mnemonic::Brk, addressing_mode::Implied> 
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Break, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),
-                gen_write_memory_microcode!(sp_pcl, pcl),
+                Microcode::WriteMemory(sp_pcl, pcl),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(sp_pch, pch),
+                Microcode::WriteMemory(sp_pch, pch),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(sp_ps, ps), // PS Register
+                Microcode::WriteMemory(sp_ps, ps), // PS Register
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 gen_write_16bit_register_microcode!(WordRegisters::Pc, irq_vector),
             ],

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -33,10 +33,10 @@ fn should_generate_absolute_addressing_mode_adc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -60,10 +60,10 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_adc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -87,10 +87,10 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_adc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -116,10 +116,10 @@ fn should_generate_indirect_y_indexed_addressing_mode_adc_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -140,10 +140,10 @@ fn should_generate_immediate_addressing_mode_adc_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -169,10 +169,10 @@ fn should_generate_x_indexed_indirect_addressing_mode_adc_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -195,10 +195,10 @@ fn should_generate_zeropage_addressing_mode_adc_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -222,10 +222,10 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_adc_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
             ]
         ),
@@ -249,8 +249,8 @@ fn should_generate_absolute_addressing_mode_and_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -273,8 +273,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_and_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -297,8 +297,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_and_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -324,8 +324,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_and_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -346,8 +346,8 @@ fn should_generate_immediate_addressing_mode_and_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -373,8 +373,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_and_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -396,8 +396,8 @@ fn should_generate_zeropage_addressing_mode_and_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -420,8 +420,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -444,9 +444,9 @@ fn should_generate_absolute_addressing_mode_asl_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
@@ -468,9 +468,9 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
@@ -491,9 +491,9 @@ fn should_generate_accumulator_addressing_mode_asl_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x54)
             ]
         ),
@@ -514,9 +514,9 @@ fn should_generate_zeropage_addressing_mode_asl_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
@@ -538,9 +538,9 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_asl_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
@@ -832,9 +832,9 @@ fn should_generate_absolute_addressing_mode_bit_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
             ]
         ),
         mc
@@ -855,9 +855,9 @@ fn should_generate_zeropage_addressing_mode_bit_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
             ]
         ),
         mc
@@ -1028,8 +1028,8 @@ fn should_generate_implied_addressing_mode_brk_machine_code() {
             0, // PC controlled by the instruction
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Break, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Break, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Interrupt, true),
                 Microcode::WriteMemory(0x01ff, 0x35), // PC (LL + 1)
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(0x01fe, 0x12), // PC (HH)
@@ -1191,7 +1191,10 @@ fn should_generate_implied_addressing_mode_clc_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Carry,
+                false
+            ),]
         ),
         mc
     );
@@ -1211,7 +1214,10 @@ fn should_generate_implied_addressing_mode_cld_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, false),]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Decimal,
+                false
+            ),]
         ),
         mc
     );
@@ -1231,7 +1237,7 @@ fn should_generate_implied_addressing_mode_cli_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(
+            vec![Microcode::SetProgramStatusFlagState(
                 ProgramStatusFlags::Interrupt,
                 false
             )]
@@ -1254,7 +1260,10 @@ fn should_generate_implied_addressing_mode_clv_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Overflow, false)]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Overflow,
+                false
+            )]
         ),
         mc
     );
@@ -1270,9 +1279,9 @@ fn should_generate_absolute_addressing_mode_cmp_machine_code() {
         Instruction::new(mnemonic::Cmp, addressing_mode::Absolute::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
@@ -1290,9 +1299,9 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_cmp_machine_code() {
     .into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
@@ -1310,9 +1319,9 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_cmp_machine_code() {
     .into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(3, 4, expected_mops.clone()), mc);
@@ -1336,9 +1345,9 @@ fn should_generate_indirect_y_indexed_addressing_mode_cmp_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1353,9 +1362,9 @@ fn should_generate_immediate_addressing_mode_cmp_machine_code() {
         Instruction::new(mnemonic::Cmp, addressing_mode::Immediate::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(2, 2, expected_mops.clone()), mc);
@@ -1379,9 +1388,9 @@ fn should_generate_x_indexed_indirect_addressing_mode_cmp_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1396,9 +1405,9 @@ fn should_generate_zeropage_addressing_mode_cmp_machine_code() {
         Instruction::new(mnemonic::Cmp, addressing_mode::ZeroPage::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(2, 3, expected_mops.clone()), mc);
@@ -1416,9 +1425,9 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_cmp_machine_code() {
     .into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+        Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
     ];
 
     assert_eq!(Operations::new(2, 4, expected_mops.clone()), mc);
@@ -1438,9 +1447,9 @@ fn should_generate_absolute_addressing_mode_cpx_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1460,9 +1469,9 @@ fn should_generate_immediate_addressing_mode_cpx_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1482,9 +1491,9 @@ fn should_generate_zeropage_addressing_mode_cpx_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1505,9 +1514,9 @@ fn should_generate_absolute_addressing_mode_cpy_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1527,9 +1536,9 @@ fn should_generate_immediate_addressing_mode_cpy_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1549,9 +1558,9 @@ fn should_generate_zeropage_addressing_mode_cpy_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
             ]
         ),
         mc
@@ -1573,8 +1582,8 @@ fn should_generate_absolute_addressing_mode_dec_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x01ff, 0x04),
             ]
         ),
@@ -1596,8 +1605,8 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_dec_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x01ff, 0x04),
             ]
         ),
@@ -1618,8 +1627,8 @@ fn should_generate_zeropage_addressing_mode_dec_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0xff, 0x04),
             ]
         ),
@@ -1641,8 +1650,8 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_dec_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0xff, 0x04),
             ]
         ),
@@ -1663,8 +1672,8 @@ fn should_generate_implied_addressing_mode_dex_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
             ]
         ),
@@ -1685,8 +1694,8 @@ fn should_generate_implied_addressing_mode_dey_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
             ]
         ),
@@ -1710,8 +1719,8 @@ fn should_generate_absolute_addressing_mode_eor_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1734,8 +1743,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_eor_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1758,8 +1767,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_eor_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1785,8 +1794,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_eor_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1807,8 +1816,8 @@ fn should_generate_immediate_addressing_mode_eor_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1834,8 +1843,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_eor_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1857,8 +1866,8 @@ fn should_generate_zeropage_addressing_mode_eor_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1881,8 +1890,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_eor_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
             ]
         ),
@@ -1905,8 +1914,8 @@ fn should_generate_absolute_addressing_mode_inc_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x01ff, 0x06),
             ]
         ),
@@ -1928,8 +1937,8 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_inc_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x01ff, 0x06),
             ]
         ),
@@ -1950,8 +1959,8 @@ fn should_generate_zeropage_addressing_mode_inc_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0xff, 0x06),
             ]
         ),
@@ -1973,8 +1982,8 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_inc_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0xff, 0x06),
             ]
         ),
@@ -1995,8 +2004,8 @@ fn should_generate_implied_addressing_mode_inx_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0x13)
             ]
         ),
@@ -2017,8 +2026,8 @@ fn should_generate_implied_addressing_mode_iny_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x13)
             ]
         ),
@@ -2114,8 +2123,8 @@ fn should_generate_immediate_addressing_mode_lda_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2135,8 +2144,8 @@ fn should_generate_zeropage_addressing_mode_lda_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::Acc,
                     0x00 // memory defaults to null
@@ -2152,8 +2161,8 @@ fn should_generate_zeropage_addressing_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 2)
             ]
@@ -2176,8 +2185,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::Acc,
                     0xff // value at 0x05 in memory should be 0xff
@@ -2194,8 +2203,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 2)
             ]
@@ -2216,8 +2225,8 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
             ]
         ),
@@ -2230,8 +2239,8 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
             ]
@@ -2252,8 +2261,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
             ]
         ),
@@ -2266,8 +2275,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
             ]
@@ -2288,8 +2297,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
             ]
         ),
@@ -2302,8 +2311,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
             ]
@@ -2329,8 +2338,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_lda_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xea)
             ]
         ),
@@ -2355,8 +2364,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_lda_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xea)
             ]
         ),
@@ -2378,8 +2387,8 @@ fn should_generate_absolute_addressing_mode_ldx_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0x00)
             ]
         ),
@@ -2399,8 +2408,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ldx_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0x00)
             ]
         ),
@@ -2420,8 +2429,8 @@ fn should_generate_immediate_addressing_mode_ldx_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
             ]
         ),
@@ -2441,8 +2450,8 @@ fn should_generate_zeropage_addressing_mode_ldx_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::X,
                     0x00 // memory defaults to null
@@ -2467,8 +2476,8 @@ fn should_generate_zeropage_indexed_with_y_addressing_mode_ldx_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::X,
                     0xff // value at 0x05 in memory should be 0xff
@@ -2493,8 +2502,8 @@ fn should_generate_absolute_addressing_mode_ldy_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
             ]
         ),
@@ -2514,8 +2523,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ldy_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
             ]
         ),
@@ -2535,8 +2544,8 @@ fn should_generate_immediate_addressing_mode_ldy_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
             ]
         ),
@@ -2556,8 +2565,8 @@ fn should_generate_zeropage_addressing_mode_ldy_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::Y,
                     0x00 // memory defaults to null
@@ -2582,8 +2591,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ldy_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(
                     ByteRegisters::Y,
                     0xff // value at 0x05 in memory should be 0xff
@@ -2609,9 +2618,9 @@ fn should_generate_absolute_addressing_mode_lsr_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
@@ -2633,9 +2642,9 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lsr_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
@@ -2656,9 +2665,9 @@ fn should_generate_accumulator_addressing_mode_lsr_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x2a)
             ]
         ),
@@ -2679,9 +2688,9 @@ fn should_generate_zeropage_addressing_mode_lsr_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
@@ -2703,9 +2712,9 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lsr_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
@@ -2740,8 +2749,8 @@ fn should_generate_absolute_addressing_mode_ora_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2764,8 +2773,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ora_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2788,8 +2797,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ora_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2815,8 +2824,8 @@ fn should_generate_indirect_y_indexed_addressing_mode_ora_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2837,8 +2846,8 @@ fn should_generate_immediate_addressing_mode_ora_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2864,8 +2873,8 @@ fn should_generate_x_indexed_indirect_addressing_mode_ora_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2887,8 +2896,8 @@ fn should_generate_zeropage_addressing_mode_ora_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2911,8 +2920,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ora_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -2991,8 +3000,8 @@ fn should_generate_implied_addressing_mode_pla_machine_code() {
             vec![],
             vec![
                 gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 1)
             ]
@@ -3049,9 +3058,9 @@ fn should_generate_absolute_addressing_mode_rol_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
@@ -3078,9 +3087,9 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_rol_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
@@ -3106,9 +3115,9 @@ fn should_generate_accumulator_addressing_mode_rol_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
             ]
         ),
@@ -3133,9 +3142,9 @@ fn should_generate_zeropage_addressing_mode_rol_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
@@ -3162,9 +3171,9 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_rol_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
@@ -3191,9 +3200,9 @@ fn should_generate_absolute_addressing_mode_ror_machine_code() {
             3,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
@@ -3220,9 +3229,9 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ror_machine_code() {
             3,
             7,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
@@ -3248,9 +3257,9 @@ fn should_generate_accumulator_addressing_mode_ror_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xd5)
             ]
         ),
@@ -3275,9 +3284,9 @@ fn should_generate_zeropage_addressing_mode_ror_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
@@ -3304,9 +3313,9 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ror_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
@@ -3394,10 +3403,10 @@ fn should_generate_absolute_addressing_mode_sbc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3426,10 +3435,10 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_sbc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3458,10 +3467,10 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_sbc_machine_code() {
             3,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3492,10 +3501,10 @@ fn should_generate_indirect_y_indexed_addressing_mode_sbc_machine_code() {
             2,
             5,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3522,10 +3531,10 @@ fn should_generate_immediate_addressing_mode_sbc_machine_code() {
             2,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3556,10 +3565,10 @@ fn should_generate_x_indexed_indirect_addressing_mode_sbc_machine_code() {
             2,
             6,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3587,10 +3596,10 @@ fn should_generate_zeropage_addressing_mode_sbc_machine_code() {
             2,
             3,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3619,10 +3628,10 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_sbc_machine_code() {
             2,
             4,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Overflow, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
             ]
         ),
@@ -3644,7 +3653,10 @@ fn should_generate_implied_addressing_mode_sec_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Carry,
+                true
+            ),]
         ),
         mc
     );
@@ -3664,7 +3676,10 @@ fn should_generate_implied_addressing_mode_sed_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Decimal, true),]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Decimal,
+                true
+            ),]
         ),
         mc
     );
@@ -3684,7 +3699,10 @@ fn should_generate_implied_addressing_mode_sei_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),]
+            vec![Microcode::SetProgramStatusFlagState(
+                ProgramStatusFlags::Interrupt,
+                true
+            ),]
         ),
         mc
     );
@@ -3921,8 +3939,8 @@ fn should_generate_implied_addressing_mode_tax_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
             ]
         ),
@@ -3942,8 +3960,8 @@ fn should_generate_implied_addressing_mode_tay_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
             ]
         ),
@@ -3962,8 +3980,8 @@ fn should_generate_implied_addressing_mode_tsx_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
             ]
         ),
@@ -3982,8 +4000,8 @@ fn should_generate_implied_addressing_mode_txa_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),
@@ -4018,8 +4036,8 @@ fn should_generate_implied_addressing_mode_tya_machine_code() {
             1,
             2,
             vec![
-                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
-                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
+                Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
             ]
         ),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -447,7 +447,7 @@ fn should_generate_absolute_addressing_mode_asl_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x54)
+                Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
         mc
@@ -471,7 +471,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_asl_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x54)
+                Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
         mc
@@ -517,7 +517,7 @@ fn should_generate_zeropage_addressing_mode_asl_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x54)
+                Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
         mc
@@ -541,7 +541,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_asl_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x54)
+                Microcode::WriteMemory(0x00ff, 0x54)
             ]
         ),
         mc
@@ -1030,11 +1030,11 @@ fn should_generate_implied_addressing_mode_brk_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Break, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Interrupt, true),
-                gen_write_memory_microcode!(0x01ff, 0x35), // PC (LL + 1)
+                Microcode::WriteMemory(0x01ff, 0x35), // PC (LL + 1)
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(0x01fe, 0x12), // PC (HH)
+                Microcode::WriteMemory(0x01fe, 0x12), // PC (HH)
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(0x01fd, u8::from(expected_ps_on_stack)), // PS Register
+                Microcode::WriteMemory(0x01fd, u8::from(expected_ps_on_stack)), // PS Register
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 gen_write_16bit_register_microcode!(WordRegisters::Pc, 0x5678),
             ]
@@ -1575,7 +1575,7 @@ fn should_generate_absolute_addressing_mode_dec_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x01ff, 0x04),
+                Microcode::WriteMemory(0x01ff, 0x04),
             ]
         ),
         mc
@@ -1598,7 +1598,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_dec_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x01ff, 0x04),
+                Microcode::WriteMemory(0x01ff, 0x04),
             ]
         ),
         mc
@@ -1620,7 +1620,7 @@ fn should_generate_zeropage_addressing_mode_dec_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0xff, 0x04),
+                Microcode::WriteMemory(0xff, 0x04),
             ]
         ),
         mc
@@ -1643,7 +1643,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_dec_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0xff, 0x04),
+                Microcode::WriteMemory(0xff, 0x04),
             ]
         ),
         mc
@@ -1907,7 +1907,7 @@ fn should_generate_absolute_addressing_mode_inc_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x01ff, 0x06),
+                Microcode::WriteMemory(0x01ff, 0x06),
             ]
         ),
         mc
@@ -1930,7 +1930,7 @@ fn should_generate_absolute_indexed_by_x_addressing_mode_inc_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x01ff, 0x06),
+                Microcode::WriteMemory(0x01ff, 0x06),
             ]
         ),
         mc
@@ -1952,7 +1952,7 @@ fn should_generate_zeropage_addressing_mode_inc_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0xff, 0x06),
+                Microcode::WriteMemory(0xff, 0x06),
             ]
         ),
         mc
@@ -1975,7 +1975,7 @@ fn should_generate_zeropage_indexed_by_x_addressing_mode_inc_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0xff, 0x06),
+                Microcode::WriteMemory(0xff, 0x06),
             ]
         ),
         mc
@@ -2089,9 +2089,9 @@ fn should_generate_absolute_addressing_mode_jsr_machine_code() {
             0, // offset modified directly by instruction
             6,
             vec![
-                gen_write_memory_microcode!(sph, pch),
+                Microcode::WriteMemory(sph, pch),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_memory_microcode!(spl, pcl),
+                Microcode::WriteMemory(spl, pcl),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
                 gen_write_16bit_register_microcode!(WordRegisters::Pc, addr)
             ]
@@ -2612,7 +2612,7 @@ fn should_generate_absolute_addressing_mode_lsr_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x2a)
+                Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
         mc
@@ -2636,7 +2636,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lsr_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x2a)
+                Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
         mc
@@ -2682,7 +2682,7 @@ fn should_generate_zeropage_addressing_mode_lsr_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x2a)
+                Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
         mc
@@ -2706,7 +2706,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lsr_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x2a)
+                Microcode::WriteMemory(0x00ff, 0x2a)
             ]
         ),
         mc
@@ -2937,7 +2937,7 @@ fn should_generate_implied_addressing_mode_pha_machine_code() {
             3,
             vec![
                 // should write to the top of the stack
-                gen_write_memory_microcode!(0x01ff, 0xff),
+                Microcode::WriteMemory(0x01ff, 0xff),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
             ]
         ),
@@ -2962,7 +2962,7 @@ fn should_generate_implied_addressing_mode_php_machine_code() {
             3,
             vec![
                 // should write to the top of the stack
-                gen_write_memory_microcode!(0x01ff, 0x55),
+                Microcode::WriteMemory(0x01ff, 0x55),
                 gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
             ]
         ),
@@ -3052,7 +3052,7 @@ fn should_generate_absolute_addressing_mode_rol_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x55)
+                Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
         mc
@@ -3081,7 +3081,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_rol_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x55)
+                Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
         mc
@@ -3136,7 +3136,7 @@ fn should_generate_zeropage_addressing_mode_rol_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x55)
+                Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
         mc
@@ -3165,7 +3165,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_rol_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0x55)
+                Microcode::WriteMemory(0x00ff, 0x55)
             ]
         ),
         mc
@@ -3194,7 +3194,7 @@ fn should_generate_absolute_addressing_mode_ror_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0xd5)
+                Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
         mc
@@ -3223,7 +3223,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ror_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0xd5)
+                Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
         mc
@@ -3278,7 +3278,7 @@ fn should_generate_zeropage_addressing_mode_ror_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0xd5)
+                Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
         mc
@@ -3307,7 +3307,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ror_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Carry, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                gen_write_memory_microcode!(0x00ff, 0xd5)
+                Microcode::WriteMemory(0x00ff, 0xd5)
             ]
         ),
         mc
@@ -3700,11 +3700,7 @@ fn should_generate_absolute_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            3,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00))]
-        ),
+        Operations::new(3, 4, vec![Microcode::WriteMemory(0x0100, 0x00)]),
         mc
     );
 }
@@ -3719,11 +3715,7 @@ fn should_generate_absolute_with_x_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            3,
-            5,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
-        ),
+        Operations::new(3, 5, vec![Microcode::WriteMemory(0x05, 0xff)]),
         mc
     );
 
@@ -3734,7 +3726,7 @@ fn should_generate_absolute_with_x_index_addressing_mode_sta_machine_code() {
             vec![],
             vec![],
             vec![
-                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
+                Microcode::WriteMemory(0x05, 0xff),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
             ]
         ],
@@ -3752,11 +3744,7 @@ fn should_generate_absolute_with_y_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            3,
-            5,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
-        ),
+        Operations::new(3, 5, vec![Microcode::WriteMemory(0x05, 0xff)]),
         mc
     );
 
@@ -3767,7 +3755,7 @@ fn should_generate_absolute_with_y_index_addressing_mode_sta_machine_code() {
             vec![],
             vec![],
             vec![
-                Microcode::WriteMemory(WriteMemory::new(0x05, 0xff)),
+                Microcode::WriteMemory(0x05, 0xff),
                 gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
             ]
         ],
@@ -3788,11 +3776,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            6,
-            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
-        ),
+        Operations::new(2, 6, vec![Microcode::WriteMemory(0xff, 0xff)]),
         mc
     );
 }
@@ -3810,11 +3794,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            6,
-            vec![Microcode::WriteMemory(WriteMemory::new(0xff, 0xff))]
-        ),
+        Operations::new(2, 6, vec![Microcode::WriteMemory(0xff, 0xff)]),
         mc
     );
 }
@@ -3827,11 +3807,7 @@ fn should_generate_zeropage_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            3,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x00))]
-        ),
+        Operations::new(2, 3, vec![Microcode::WriteMemory(0x01, 0x00)]),
         mc
     );
 }
@@ -3846,11 +3822,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sta_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0xff))]
-        ),
+        Operations::new(2, 4, vec![Microcode::WriteMemory(0x05, 0xff)]),
         mc
     );
 }
@@ -3863,11 +3835,7 @@ fn should_generate_absolute_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            3,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x55))]
-        ),
+        Operations::new(3, 4, vec![Microcode::WriteMemory(0x0100, 0x55)]),
         mc
     );
 }
@@ -3880,11 +3848,7 @@ fn should_generate_zeropage_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            3,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x55))]
-        ),
+        Operations::new(2, 3, vec![Microcode::WriteMemory(0x01, 0x55)]),
         mc
     );
 }
@@ -3899,11 +3863,7 @@ fn should_generate_zeropage_with_y_index_addressing_mode_stx_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0x55))]
-        ),
+        Operations::new(2, 4, vec![Microcode::WriteMemory(0x05, 0x55)]),
         mc
     );
 }
@@ -3916,11 +3876,7 @@ fn should_generate_absolute_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            3,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x55))]
-        ),
+        Operations::new(3, 4, vec![Microcode::WriteMemory(0x0100, 0x55)]),
         mc
     );
 }
@@ -3933,11 +3889,7 @@ fn should_generate_zeropage_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            3,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x01, 0x55))]
-        ),
+        Operations::new(2, 3, vec![Microcode::WriteMemory(0x01, 0x55)]),
         mc
     );
 }
@@ -3952,11 +3904,7 @@ fn should_generate_zeropage_with_x_index_addressing_mode_sty_machine_code() {
     let mc = op.generate(&cpu);
 
     assert_eq!(
-        Operations::new(
-            2,
-            4,
-            vec![Microcode::WriteMemory(WriteMemory::new(0x05, 0x55))]
-        ),
+        Operations::new(2, 4, vec![Microcode::WriteMemory(0x05, 0x55)]),
         mc
     );
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -37,7 +37,7 @@ fn should_generate_absolute_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -64,7 +64,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -91,7 +91,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -120,7 +120,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -144,7 +144,7 @@ fn should_generate_immediate_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -173,7 +173,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -199,7 +199,7 @@ fn should_generate_zeropage_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -226,7 +226,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_adc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x7f)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x7f)
             ]
         ),
         mc
@@ -251,7 +251,7 @@ fn should_generate_absolute_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -275,7 +275,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -299,7 +299,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -326,7 +326,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -348,7 +348,7 @@ fn should_generate_immediate_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -375,7 +375,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -398,7 +398,7 @@ fn should_generate_zeropage_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -422,7 +422,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_and_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -494,7 +494,7 @@ fn should_generate_accumulator_addressing_mode_asl_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x54)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x54)
             ]
         ),
         mc
@@ -566,7 +566,7 @@ fn should_generate_bcc_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -588,7 +588,7 @@ fn should_generate_bcc_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -609,7 +609,7 @@ fn should_generate_bcc_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -633,7 +633,7 @@ fn should_generate_bcs_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -655,7 +655,7 @@ fn should_generate_bcs_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -676,7 +676,7 @@ fn should_generate_bcs_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -700,7 +700,7 @@ fn should_generate_beq_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -722,7 +722,7 @@ fn should_generate_beq_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -743,7 +743,7 @@ fn should_generate_beq_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -767,7 +767,7 @@ fn should_generate_bmi_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -789,7 +789,7 @@ fn should_generate_bmi_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -810,7 +810,7 @@ fn should_generate_bmi_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -882,7 +882,7 @@ fn should_generate_bne_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -904,7 +904,7 @@ fn should_generate_bne_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -925,7 +925,7 @@ fn should_generate_bne_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -949,7 +949,7 @@ fn should_generate_bpl_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -971,7 +971,7 @@ fn should_generate_bpl_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -992,7 +992,7 @@ fn should_generate_bpl_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1031,12 +1031,12 @@ fn should_generate_implied_addressing_mode_brk_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Break, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Interrupt, true),
                 Microcode::WriteMemory(0x01ff, 0x35), // PC (LL + 1)
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(0x01fe, 0x12), // PC (HH)
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(0x01fd, u8::from(expected_ps_on_stack)), // PS Register
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, 0x5678),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write16bitRegister(WordRegisters::Pc, 0x5678),
             ]
         ),
         mc
@@ -1061,7 +1061,7 @@ fn should_generate_bvc_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1083,7 +1083,7 @@ fn should_generate_bvc_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1104,7 +1104,7 @@ fn should_generate_bvc_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1128,7 +1128,7 @@ fn should_generate_bvs_machine_code_with_branch_penalty() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1150,7 +1150,7 @@ fn should_generate_bvs_machine_code_with_branch_and_page_penalty() {
         Operations::new(
             0,
             4,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1171,7 +1171,7 @@ fn should_generate_bvs_machine_code_with_no_jump() {
         Operations::new(
             0,
             2,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, pc)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, pc)]
         ),
         mc
     );
@@ -1674,7 +1674,7 @@ fn should_generate_implied_addressing_mode_dex_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_dec_8bit_register_microcode!(ByteRegisters::X, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::X, 1),
             ]
         ),
         mc
@@ -1696,7 +1696,7 @@ fn should_generate_implied_addressing_mode_dey_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Y, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Y, 1),
             ]
         ),
         mc
@@ -1721,7 +1721,7 @@ fn should_generate_absolute_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1745,7 +1745,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1769,7 +1769,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1796,7 +1796,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1818,7 +1818,7 @@ fn should_generate_immediate_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1845,7 +1845,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1868,7 +1868,7 @@ fn should_generate_zeropage_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -1892,7 +1892,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_eor_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xaa)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xaa)
             ]
         ),
         mc
@@ -2006,7 +2006,7 @@ fn should_generate_implied_addressing_mode_inx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0x13)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0x13)
             ]
         ),
         mc
@@ -2028,7 +2028,7 @@ fn should_generate_implied_addressing_mode_iny_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x13)
+                Microcode::Write8bitRegister(ByteRegisters::Y, 0x13)
             ]
         ),
         mc
@@ -2049,7 +2049,7 @@ fn should_generate_absolute_addressing_mode_jmp_machine_code() {
         Operations::new(
             0,
             3,
-            vec![gen_write_16bit_register_microcode!(WordRegisters::Pc, addr)]
+            vec![Microcode::Write16bitRegister(WordRegisters::Pc, addr)]
         ),
         mc
     );
@@ -2070,7 +2070,7 @@ fn should_generate_indirect_addressing_mode_jmp_machine_code() {
         Operations::new(
             0, // offset modified directly by operation
             5,
-            vec![gen_write_16bit_register_microcode!(
+            vec![Microcode::Write16bitRegister(
                 WordRegisters::Pc,
                 indirect_addr
             )]
@@ -2099,10 +2099,10 @@ fn should_generate_absolute_addressing_mode_jsr_machine_code() {
             6,
             vec![
                 Microcode::WriteMemory(sph, pch),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::WriteMemory(spl, pcl),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, addr)
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write16bitRegister(WordRegisters::Pc, addr)
             ]
         ),
         mc
@@ -2125,7 +2125,7 @@ fn should_generate_immediate_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2146,7 +2146,7 @@ fn should_generate_zeropage_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::Acc,
                     0x00 // memory defaults to null
                 )
@@ -2163,8 +2163,8 @@ fn should_generate_zeropage_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 2)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -2187,7 +2187,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::Acc,
                     0xff // value at 0x05 in memory should be 0xff
                 )
@@ -2205,8 +2205,8 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 2)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -2227,7 +2227,7 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00)
             ]
         ),
         mc
@@ -2241,8 +2241,8 @@ fn should_generate_absolute_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -2263,7 +2263,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00)
             ]
         ),
         mc
@@ -2277,8 +2277,8 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -2299,7 +2299,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00)
             ]
         ),
         mc
@@ -2313,8 +2313,8 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x00),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x00),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -2340,7 +2340,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xea)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xea)
             ]
         ),
         mc
@@ -2366,7 +2366,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_lda_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xea)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xea)
             ]
         ),
         mc
@@ -2389,7 +2389,7 @@ fn should_generate_absolute_addressing_mode_ldx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0x00)
             ]
         ),
         mc
@@ -2410,7 +2410,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ldx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0x00)
             ]
         ),
         mc
@@ -2431,7 +2431,7 @@ fn should_generate_immediate_addressing_mode_ldx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0xff)
             ]
         ),
         mc
@@ -2452,7 +2452,7 @@ fn should_generate_zeropage_addressing_mode_ldx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::X,
                     0x00 // memory defaults to null
                 )
@@ -2478,7 +2478,7 @@ fn should_generate_zeropage_indexed_with_y_addressing_mode_ldx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::X,
                     0xff // value at 0x05 in memory should be 0xff
                 )
@@ -2504,7 +2504,7 @@ fn should_generate_absolute_addressing_mode_ldy_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::Y, 0x00)
             ]
         ),
         mc
@@ -2525,7 +2525,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ldy_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x00)
+                Microcode::Write8bitRegister(ByteRegisters::Y, 0x00)
             ]
         ),
         mc
@@ -2546,7 +2546,7 @@ fn should_generate_immediate_addressing_mode_ldy_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Y, 0xff)
             ]
         ),
         mc
@@ -2567,7 +2567,7 @@ fn should_generate_zeropage_addressing_mode_ldy_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, true),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::Y,
                     0x00 // memory defaults to null
                 )
@@ -2593,7 +2593,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ldy_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(
+                Microcode::Write8bitRegister(
                     ByteRegisters::Y,
                     0xff // value at 0x05 in memory should be 0xff
                 )
@@ -2668,7 +2668,7 @@ fn should_generate_accumulator_addressing_mode_lsr_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x2a)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x2a)
             ]
         ),
         mc
@@ -2751,7 +2751,7 @@ fn should_generate_absolute_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2775,7 +2775,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2799,7 +2799,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2826,7 +2826,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2848,7 +2848,7 @@ fn should_generate_immediate_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2875,7 +2875,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2898,7 +2898,7 @@ fn should_generate_zeropage_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2922,7 +2922,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_ora_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -2947,7 +2947,7 @@ fn should_generate_implied_addressing_mode_pha_machine_code() {
             vec![
                 // should write to the top of the stack
                 Microcode::WriteMemory(0x01ff, 0xff),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
             ]
         ),
         mc
@@ -2972,7 +2972,7 @@ fn should_generate_implied_addressing_mode_php_machine_code() {
             vec![
                 // should write to the top of the stack
                 Microcode::WriteMemory(0x01ff, 0x55),
-                gen_dec_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Dec8bitRegister(ByteRegisters::Sp, 1),
             ]
         ),
         mc
@@ -2999,11 +2999,11 @@ fn should_generate_implied_addressing_mode_pla_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 1)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 1)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -3030,9 +3030,9 @@ fn should_generate_implied_addressing_mode_plp_machine_code() {
             vec![],
             vec![],
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_8bit_register_microcode!(ByteRegisters::Ps, 0x55),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 1)
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write8bitRegister(ByteRegisters::Ps, 0x55),
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 1)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -3118,7 +3118,7 @@ fn should_generate_accumulator_addressing_mode_rol_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0x55)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0x55)
             ]
         ),
         mc
@@ -3260,7 +3260,7 @@ fn should_generate_accumulator_addressing_mode_ror_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Carry, false),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xd5)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xd5)
             ]
         ),
         mc
@@ -3347,10 +3347,10 @@ fn should_generate_implied_addressing_mode_rti_machine_code() {
             1,
             6,
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 1),
-                gen_write_8bit_register_microcode!(ByteRegisters::Ps, 0x20),
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 2),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, 0x1234)
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 1),
+                Microcode::Write8bitRegister(ByteRegisters::Ps, 0x20),
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 2),
+                Microcode::Write16bitRegister(WordRegisters::Pc, 0x1234)
             ]
         ),
         mc
@@ -3373,8 +3373,8 @@ fn should_generate_implied_addressing_mode_rts_machine_code() {
             1,
             6,
             vec![
-                gen_inc_8bit_register_microcode!(ByteRegisters::Sp, 2),
-                gen_write_16bit_register_microcode!(WordRegisters::Pc, 0x6002)
+                Microcode::Inc8bitRegister(ByteRegisters::Sp, 2),
+                Microcode::Write16bitRegister(WordRegisters::Pc, 0x6002)
             ]
         ),
         mc
@@ -3407,7 +3407,7 @@ fn should_generate_absolute_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3439,7 +3439,7 @@ fn should_generate_absolute_indexed_with_x_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3471,7 +3471,7 @@ fn should_generate_absolute_indexed_with_y_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3505,7 +3505,7 @@ fn should_generate_indirect_y_indexed_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3535,7 +3535,7 @@ fn should_generate_immediate_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3569,7 +3569,7 @@ fn should_generate_x_indexed_indirect_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3600,7 +3600,7 @@ fn should_generate_zeropage_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3632,7 +3632,7 @@ fn should_generate_zeropage_indexed_with_x_addressing_mode_sbc_machine_code() {
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Overflow, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xa0)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xa0)
             ]
         ),
         mc
@@ -3745,7 +3745,7 @@ fn should_generate_absolute_with_x_index_addressing_mode_sta_machine_code() {
             vec![],
             vec![
                 Microcode::WriteMemory(0x05, 0xff),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -3774,7 +3774,7 @@ fn should_generate_absolute_with_y_index_addressing_mode_sta_machine_code() {
             vec![],
             vec![
                 Microcode::WriteMemory(0x05, 0xff),
-                gen_inc_16bit_register_microcode!(WordRegisters::Pc, 3)
+                Microcode::Inc16bitRegister(WordRegisters::Pc, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -3941,7 +3941,7 @@ fn should_generate_implied_addressing_mode_tax_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0xff)
             ]
         ),
         mc
@@ -3962,7 +3962,7 @@ fn should_generate_implied_addressing_mode_tay_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Y, 0xff)
             ]
         ),
         mc
@@ -3982,7 +3982,7 @@ fn should_generate_implied_addressing_mode_tsx_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::X, 0xff)
             ]
         ),
         mc
@@ -4002,7 +4002,7 @@ fn should_generate_implied_addressing_mode_txa_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc
@@ -4019,7 +4019,7 @@ fn should_generate_implied_addressing_mode_txs_machine_code() {
         Operations::new(
             1,
             2,
-            vec![gen_write_8bit_register_microcode!(ByteRegisters::Sp, 0x00)]
+            vec![Microcode::Write8bitRegister(ByteRegisters::Sp, 0x00)]
         ),
         mc
     );
@@ -4038,7 +4038,7 @@ fn should_generate_implied_addressing_mode_tya_machine_code() {
             vec![
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Negative, true),
                 Microcode::SetProgramStatusFlagState(ProgramStatusFlags::Zero, false),
-                gen_write_8bit_register_microcode!(ByteRegisters::Acc, 0xff)
+                Microcode::Write8bitRegister(ByteRegisters::Acc, 0xff)
             ]
         ),
         mc


### PR DESCRIPTION
# Introduction
Similarly to #322, this PR makes some refactors to the MOS6502 microcode implementation to no-longer nest the concrete type of each variant under the Microcode enum. Instead all necessary fields to instantiate the concrete type are directly enclosed in the enum, with the concrete type effectively functioning for complex trait implementations internally. As such all concrete implementations of the Microcode variants have been moved to crate-level visibility, with the intent of the Microcode enum being the public interface into this construct.

# Linked Issues
resolves #323 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
