### PR TITLE
implement `with_inner` on display

### DIFF
--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -49,6 +49,17 @@ impl Display {
         }
     }
 
+    /// Provides a function handler for making changes to the inner display
+    /// representation.
+    pub fn with_inner<F>(mut self, f: F) -> Self
+    where
+        F: Fn([[bool; 64]; 32]) -> [[bool; 64]; 32],
+    {
+        let inner = self.inner;
+        self.inner = (f)(inner);
+        self
+    }
+
     /// Provides a function handler for making mutable changes to the inner display
     /// representation.
     pub fn with_inner_mut<F, B>(&mut self, f: F) -> B

--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -86,8 +86,10 @@ impl Display {
     pub fn write_pixel_mut(&mut self, x: usize, y: usize, pixel_on: bool) -> Option<bool> {
         self.pixel(x, y).map(|previous_value| {
             // if we can get the previous value, it's safe to write a new one.
-            self.inner[y][x] = pixel_on;
-            previous_value
+            self.with_inner_mut(|display| {
+                display[y][x] = pixel_on;
+                previous_value
+            })
         })
     }
 


### PR DESCRIPTION
# Introduction
Small change to Display to implement a `with_inner` method for modifying displays.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
