### PR TITLE
Buffered random generator

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -71,19 +71,19 @@ impl BufferedRandomNumberGenerator {
     where
         RNG: GenerateRandom<u8> + Send + 'static,
     {
-        let (sender, receiver) = std::sync::mpsc::sync_channel(bound);
+        let (tx, rx) = std::sync::mpsc::sync_channel(bound);
 
         // fork a thread off that will continuously try to fill the buffer. If
         // the buffer is full, the thread will block.
         std::thread::spawn(move || loop {
             // When parent receiver is dropped, the send returns an Err and
             // the thread returns.
-            if let Err(_) = sender.send(rng.random()) {
+            if let Err(_) = tx.send(rng.random()) {
                 return;
             }
         });
 
-        Self { buffer: receiver }
+        Self { buffer: rx }
     }
 }
 

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -76,7 +76,7 @@ impl BufferedRandomNumberGenerator {
         // fork a thread off that will continuously try to fill the buffer. If
         // the buffer is full, the thread will block.
         std::thread::spawn(move || loop {
-            // when parent receiver is dropped, the send returns an err and
+            // When parent receiver is dropped, the send returns an Err and
             // the thread returns.
             if let Err(_) = sender.send(rng.random()) {
                 return;

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -75,12 +75,10 @@ impl BufferedRandomNumberGenerator {
 
         // fork a thread off that will continuously try to fill the buffer. If
         // the buffer is full, the thread will block.
-        std::thread::spawn(move || loop {
+        std::thread::spawn(move || {
             // When parent receiver is dropped, the send returns an Err and
             // the thread returns.
-            if let Err(_) = tx.send(rng.random()) {
-                return;
-            }
+            while let Ok(_) = tx.send(rng.random()) {}
         });
 
         Self { buffer: rx }

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -78,7 +78,7 @@ impl BufferedRandomNumberGenerator {
         std::thread::spawn(move || {
             // When parent receiver is dropped, the send returns an Err and
             // the thread returns.
-            while let Ok(_) = tx.send(rng.random()) {}
+            while tx.send(rng.random()).is_ok() {}
         });
 
         Self { buffer: rx }

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -29,6 +29,7 @@ where
     }
 }
 
+#[cfg(target_family = "unix")]
 /// Generates a random byte using `/dev/random` as the seed for data.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct UnixRandomNumberGenerator;

--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -91,6 +91,7 @@ impl GenerateRandom<u8> for BufferedRandomNumberGenerator {
     fn random(&self) -> u8 {
         self.buffer
             .recv()
+            // this should never fail as long as self is still alive.
             .expect("cannot read exactly one byte from buffer.")
     }
 }


### PR DESCRIPTION
# Introduction
This PR provides a buffered and asynchronous random number generator implementation that will eagerly attempt to fill a buffer with random numbers, blocking when full. Optionally this can be seeded equivalently to the current process of passing a closure.

`BufferedRandomNumberGenerator::with_capacity(1024, || 0u8)` or `BufferedRandomNumberGenerator::with_capacity(1024, UnixRandomNumberGenerator)`
# Linked Issues
resolves #286 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
