### PR TITLE
`UnixRandomNumberGenerator` should only be generated on unix systems

### DIFF
--- a/src/cpu/chip8/mod.rs
+++ b/src/cpu/chip8/mod.rs
@@ -34,6 +34,7 @@ where
 #[derive(Default, Debug, Clone, Copy)]
 pub struct UnixRandomNumberGenerator;
 
+#[cfg(target_family = "unix")]
 impl GenerateRandom<u8> for UnixRandomNumberGenerator {
     fn random(&self) -> u8 {
         use std::fs;


### PR DESCRIPTION
# Introduction
This is a small PR fix to limit all trait implementations, and mentions of `UnixRandomNumberGenerator` to unix systems.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
