### PR TITLE
Mark `Mos6502` address_map for public visibility

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -43,7 +43,7 @@ pub type Rom = Memory<ReadOnly, u16, u8>;
 /// Mos6502 represents the 6502 CPU
 #[derive(Debug, Clone)]
 pub struct Mos6502 {
-    address_map: AddressMap<u16, u8>,
+    pub address_map: AddressMap<u16, u8>,
     pub acc: GeneralPurpose,
     pub x: GeneralPurpose,
     pub y: GeneralPurpose,


### PR DESCRIPTION
# Introduction
Small PR to mark address_map on the `Mos6502` CPU as public visibility to match with it's other registers.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
