### PR TITLE
Feature/330/interior mutability for address space subfield of mos6502 cpu

### DIFF
--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -81,8 +81,8 @@ impl Addressable<u16, u8> for Memory<ReadWrite, u16, u8> {
         self.inner[usize::from(addr_offset)]
     }
 
-    /// Assigns a single value to an address in memory returning a result if the
-    /// write was in range.
+    /// Assigns a single value to an address in memory returning a result
+    /// wrapping the written value if the write was in range.
     fn write(&mut self, addr: u16, value: u8) -> Result<u8, String> {
         let addr_offset = addr - self.start_address;
         self.inner[usize::from(addr_offset)] = value;

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -136,9 +136,12 @@ impl Mos6502 {
     /// an owned CPU returning the modified instance representation.
     pub fn with_owned_address_map<F>(mut self, f: F) -> Self
     where
-        F: Fn(&mut AddressMap<u16, u8>),
+        F: Fn(AddressMap<u16, u8>) -> AddressMap<u16, u8>,
     {
-        (f)(&mut self.address_map);
+        let src_address_map =
+            std::mem::replace(&mut self.address_map, AddressMap::<u16, u8>::new());
+        let modified_address_map = (f)(src_address_map);
+        let _ = std::mem::replace(&mut self.address_map, modified_address_map);
         self
     }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -132,6 +132,33 @@ impl Mos6502 {
         )
     }
 
+    /// Provides a function handler for making changes to the address_map of
+    /// an owned CPU returning the modified instance representation.
+    pub fn with_owned_address_map<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mut AddressMap<u16, u8>),
+    {
+        (f)(&mut self.address_map);
+        self
+    }
+
+    /// Provides a function handler for accessing a borrowed address map..
+    pub fn with_address_map<F, B>(&self, f: F) -> B
+    where
+        F: Fn(&AddressMap<u16, u8>) -> B,
+    {
+        (f)(&self.address_map)
+    }
+
+    /// Provides a function handler for making mutable changes to the address_map
+    /// representation.
+    pub fn with_address_map_mut<F, B>(&mut self, f: F) -> B
+    where
+        F: Fn(&mut AddressMap<u16, u8>) -> B,
+    {
+        (f)(&mut self.address_map)
+    }
+
     /// Provides a wrapper to update a general-purpose register in a way that
     /// returns the entire cpu after modification.
     pub fn with_gp_register(mut self, reg_type: GpRegister, reg: GeneralPurpose) -> Self {

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -138,10 +138,11 @@ impl Mos6502 {
     where
         F: Fn(AddressMap<u16, u8>) -> AddressMap<u16, u8>,
     {
-        let src_address_map =
-            std::mem::replace(&mut self.address_map, AddressMap::<u16, u8>::new());
-        let modified_address_map = (f)(src_address_map);
-        let _ = std::mem::replace(&mut self.address_map, modified_address_map);
+        use std::mem::replace;
+
+        let am = replace(&mut self.address_map, AddressMap::<u16, u8>::new());
+        let am = (f)(am);
+        let _ = replace(&mut self.address_map, am);
         self
     }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -29,6 +29,23 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> Mos6502 {
 }
 
 #[test]
+fn should_access_address_map_through_wrapper_methods() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![]);
+    cpu.address_map.write(0x00ff, 0xea).unwrap();
+
+    assert_eq!(0xea, cpu.with_address_map(|am| am.read(0xff)));
+    assert_eq!(
+        Ok(0xff),
+        cpu.with_address_map_mut(|am| { am.write(0xff, 0xff) })
+    );
+
+    let cpu = cpu.with_owned_address_map(|am| {
+        let _ = am.write(0xff, 0xea);
+    });
+    assert_eq!(0xea, cpu.address_map.read(0xff));
+}
+
+#[test]
 fn should_cycle_on_adc_absolute_operation_with_overflow() {
     let mut cpu = generate_test_cpu_with_instructions(vec![0x6d, 0xff, 0x00])
         .with_gp_register(GpRegister::Acc, register::GeneralPurpose::with_value(0x80));

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -39,8 +39,9 @@ fn should_access_address_map_through_wrapper_methods() {
         cpu.with_address_map_mut(|am| { am.write(0xff, 0xff) })
     );
 
-    let cpu = cpu.with_owned_address_map(|am| {
+    let cpu = cpu.with_owned_address_map(|mut am| {
         let _ = am.write(0xff, 0xea);
+        am
     });
     assert_eq!(0xea, cpu.address_map.read(0xff));
 }


### PR DESCRIPTION
# Introduction
This PR adds 3 new methods to the `Mos6502` CPU for accessing and modifying the address map in place.

- with_address_map: takes a function closure that takes a borrowed address_map from the wrapping cpu as an arg. Generic over return types
- with_address_map_mut: takes a function closure that takes a mutably borrowed address_map from the wrapping cpu as an arg. Generic over return types
- with_owned_address_map: takes a function closure that takes ownership of the address map, returning the modified addressing_map.
# Linked Issues
resolves #330 

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
