### PR TITLE
Fixes `clippy::needless_borrow` lint

### DIFF
--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -180,7 +180,6 @@ where
 pub struct OpcodeVariantParser;
 
 impl<'a> Parser<'a, &'a [(usize, u8)], Opcode> for OpcodeVariantParser {
-    #[allow(clippy::type_complexity)]
     fn parse(&self, input: &'a [(usize, u8)]) -> parcel::ParseResult<&'a [(usize, u8)], Opcode> {
         let ms = input.get(0..2).map(|v| [v[0].1, v[1].1]).and_then(|bytes| {
             let [[first, second], [third, fourth]] =

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -58,11 +58,11 @@ impl Mos6502 {
     }
 
     /// instantiates a new Mos6502 with a provided address_map.
-    #[allow(clippy::field_reassign_with_default)]
     pub fn with_addressmap(am: AddressMap<u16, u8>) -> Self {
-        let mut cpu = Self::default();
-        cpu.address_map = am;
-        cpu
+        Self {
+            address_map: am,
+            ..Default::default()
+        }
     }
 
     /// Functions as a wrapper around the `with_addressmap` and `register`

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -122,7 +122,6 @@ impl std::ops::Add for Operand<u8> {
 impl AddTwosComplement for Operand<u8> {
     type Output = Self;
 
-    #[allow(clippy::nonminimal_bool)]
     fn twos_complement_add(self, other: Self, carry: bool) -> (Self::Output, bool) {
         let sum = self + other;
         let (lhs, rhs) = (self.unwrap(), other.unwrap());

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -888,9 +888,7 @@ impl<'a> Parser<'a, &'a [u8], InstructionVariant> for VariantParser {
                     inner,
                 })
             }
-            Ok(parcel::MatchStatus::NoMatch(_)) => {
-                Ok(parcel::MatchStatus::NoMatch(&preparse_input))
-            }
+            Ok(parcel::MatchStatus::NoMatch(_)) => Ok(parcel::MatchStatus::NoMatch(preparse_input)),
 
             Err(e) => Err(e),
         }


### PR DESCRIPTION
# Introduction
Small PR to correct a needless borrow raised by clippy.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
