### PR TITLE
Simplify iterators to satisfy clippy lints

### DIFF
--- a/src/address_map/mod.rs
+++ b/src/address_map/mod.rs
@@ -135,8 +135,7 @@ where
         self.inner
             .keys()
             .filter(|key| key.contains(&addr))
-            .map(|r| self.inner.get(r))
-            .flatten()
+            .flat_map(|r| self.inner.get(r))
             .next()
             .map_or(<V>::default(), |a| a.read(addr))
     }

--- a/src/cpu/chip8/display.rs
+++ b/src/cpu/chip8/display.rs
@@ -110,8 +110,7 @@ impl Display {
         // sprite starts in display boundary
         is_within_display_boundary((x, y)).then(|| {
             (0..8u8)
-                .map(|x| (0..5usize).map(|y| (x, y)).collect::<Vec<_>>())
-                .flatten()
+                .flat_map(|x| (0..5usize).map(|y| (x, y)).collect::<Vec<_>>())
                 .fold(false, |collision, (x_offset, y_offset)| {
                     let bit = (font_bytes[y_offset] >> (7 - x_offset)) & 0x1;
                     let bit_is_set = bit != 0;

--- a/src/cpu/chip8/operations/mod.rs
+++ b/src/cpu/chip8/operations/mod.rs
@@ -330,12 +330,11 @@ impl<R> Generate<Chip8<R>> for Drw {
 
         // check for collisions.
         let (collision, pixels) = (0..8u8)
-            .map(|x| {
+            .flat_map(|x| {
                 (0..sprite_size as usize)
                     .map(|y| (x, y))
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .fold(
                 (false, vec![]),
                 |(collision, mut pixel_writes), (x_offset, y_offset)| {

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -220,8 +220,7 @@ impl Cpu<Mos6502> for Mos6502 {
         let state = self
             .clone()
             .into_iter()
-            .map(Into::<Vec<Vec<microcode::Microcode>>>::into)
-            .flatten() // flatten instructions to cycles
+            .flat_map(Into::<Vec<Vec<microcode::Microcode>>>::into)
             .take(cycles)
             .flatten()
             .fold(self, |c, mc| Execute::execute(mc, c));


### PR DESCRIPTION
# Introduction
This PR includes a few changes to simplify iterators. Most fixes are `map(..).flatten()` -> `flat_map(..)`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
