### PR TITLE
fix: correct Cargo.toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mainspring"
-version = "1.0.0"
+version = "0.2.1"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2021"
 


### PR DESCRIPTION
# Introduction
The Cargo.toml needs to align with the current version to work with the current release process. This changes it to `0.2.1` from `1.0.0`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
